### PR TITLE
fix(auth): force full page reload on auth navigation

### DIFF
--- a/app/components/AppSidebar.vue
+++ b/app/components/AppSidebar.vue
@@ -18,7 +18,7 @@ const userEmail = computed(() => session.value?.user?.email ?? '')
 async function handleSignOut() {
   isSigningOut.value = true
   await authClient.signOut()
-  await navigateTo('/auth/sign-in')
+  await navigateTo('/auth/sign-in', { external: true })
 }
 
 const navItems = [

--- a/app/pages/auth/sign-in.vue
+++ b/app/pages/auth/sign-in.vue
@@ -43,7 +43,7 @@ async function handleSignIn() {
     return
   }
 
-  await navigateTo('/dashboard')
+  await navigateTo('/dashboard', { external: true })
 }
 </script>
 

--- a/app/pages/auth/sign-up.vue
+++ b/app/pages/auth/sign-up.vue
@@ -49,7 +49,7 @@ async function handleSignUp() {
     return
   }
 
-  await navigateTo('/onboarding/create-org')
+  await navigateTo('/onboarding/create-org', { external: true })
 }
 </script>
 


### PR DESCRIPTION
## Summary

## What does this PR change?

- This PR forces a full page reload on authentication-related navigation (sign in, sign up, and sign out) instead of relying on client-side navigation.

- Specifically, it ensures that after auth state changes, the app performs a hard reload to reflect the correct authenticated route.

## Why is this needed?

There are several issues with the current navigation behavior:

- On the Sign In page, after clicking "Sign In", the UI gets stuck on "Signing in..." and does not navigate to the dashboard. A manual refresh (F5) is required to proceed to /dashboard.

- On the Sign Up page, after signing up, the app redirects to /auth/sign-in. However, after a manual refresh, it correctly redirects to /onboarding/create-org.

- On Sign Out, after clicking "Sign Out", the app remains stuck on the dashboard. Only after refreshing does it redirect to /auth/sign-in.

Because the authentication state appears to be correctly updated but the client-side router does not immediately reflect it, forcing a full page reload ensures the correct route is rendered based on the updated auth state.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Validation

- [x] I tested locally
- [ ] I added/updated relevant documentation
- [ ] I verified multi-tenant scoping and auth behavior for affected API paths

## DCO

- [ ] All commits in this PR are signed off (`Signed-off-by`) via `git commit -s`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated navigation handling across authentication workflows (sign-out, sign-in, and sign-up) for improved performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->