### PR TITLE
feat: clear Nuxt data on sign out and after sign-in/sign-up for a full page reload

### DIFF
--- a/app/components/AppSidebar.vue
+++ b/app/components/AppSidebar.vue
@@ -18,6 +18,7 @@ const userEmail = computed(() => session.value?.user?.email ?? '')
 async function handleSignOut() {
   isSigningOut.value = true
   await authClient.signOut()
+  clearNuxtData()
   await navigateTo('/auth/sign-in')
 }
 

--- a/app/pages/auth/sign-in.vue
+++ b/app/pages/auth/sign-in.vue
@@ -43,6 +43,7 @@ async function handleSignIn() {
     return
   }
 
+  clearNuxtData()
   await navigateTo('/dashboard')
 }
 </script>

--- a/app/pages/auth/sign-up.vue
+++ b/app/pages/auth/sign-up.vue
@@ -49,6 +49,7 @@ async function handleSignUp() {
     return
   }
 
+  clearNuxtData()
   await navigateTo('/onboarding/create-org')
 }
 </script>


### PR DESCRIPTION
## Summary

**What does this PR change?**

Adds `clearNuxtData()` before `navigateTo()` in three auth flows:
- Sign-in (sign-in.vue) — after successful `authClient.signIn.email()`
- Sign-up (sign-up.vue) — after successful `authClient.signUp.email()`
- Sign-out (AppSidebar.vue) — after `authClient.signOut()`

**Why is this needed?**

All auth middleware (auth.ts, guest.ts, require-org.ts) checks session state via `authClient.useSession(useFetch)`, which caches results through Nuxt's data-fetching layer. After auth state changes (sign-in/sign-up/sign-out), the cookie updates but the cached session data remains stale. This causes:

- **Sign-in:** UI stuck on "Signing in…" — middleware still sees no session, blocks navigation to `/dashboard`
- **Sign-up:** Redirects to `/auth/sign-in` instead of `/onboarding/create-org` — middleware sees stale unauthenticated state
- **Sign-out:** Dashboard stays visible — middleware still sees the old authenticated session

Calling `clearNuxtData()` invalidates all `useFetch`/`useAsyncData` caches, forcing middleware to fetch fresh session data on the next navigation. This fixes all three issues without resorting to full page reloads (`external: true`), preserving smooth client-side transitions.

This is the proper fix for the issue reported in PR #43.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Validation

- [x] I tested locally
- [ ] I added/updated relevant documentation
- [x] I verified multi-tenant scoping and auth behavior for affected API paths
