### PR TITLE
Fix/stale-applirank-env-vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,10 +55,6 @@ NUXT_PUBLIC_SITE_URL=http://localhost:3000
 # Set to an org slug to make that org read-only (blocks all mutations)
 # Default seeded slug: reqcore-demo
 # DEMO_ORG_SLUG=reqcore-demo
-#
-# Email pre-filled on the sign-in page for the live demo account.
-# Must match the email used when seeding the database (see server/scripts/seed.ts).
-# LIVE_DEMO_EMAIL=demo@reqcore.com
 
 # ─── Optional: Trusted Proxy ─────────────────────────────────────────────────
 # IP of the reverse proxy (Cloudflare, Railway, nginx). Enables accurate
@@ -69,4 +65,4 @@ NUXT_PUBLIC_SITE_URL=http://localhost:3000
 # Fine-grained GitHub PAT with Issues:write scope
 # GITHUB_FEEDBACK_TOKEN=ghp_...
 # GitHub repo in "owner/repo" format
-# GITHUB_FEEDBACK_REPO=reqcore-inc/reqcore
+# GITHUB_FEEDBACK_REPO=reqcore/reqcore

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -59,10 +59,18 @@ export default defineNuxtConfig({
       /** When set, the dashboard shows a read-only demo banner for this org slug */
       demoOrgSlug: process.env.DEMO_ORG_SLUG || (isRailwayPreview ? 'reqcore-demo' : ''),
       /** Public live-demo account email used to prefill sign-in */
-      liveDemoEmail:
-        process.env.LIVE_DEMO_EMAIL
-        || process.env.DEMO_EMAIL
-        || 'demo@reqcore.com',
+      liveDemoEmail: (() => {
+        const email =
+          process.env.LIVE_DEMO_EMAIL
+          || process.env.DEMO_EMAIL
+          || 'demo@reqcore.com'
+        // Guard against stale applirank.com domain from old env vars
+        if (email.endsWith('@applirank.com')) {
+          console.warn('[config] Stale demo email detected (applirank.com domain) — falling back to demo@reqcore.com')
+          return 'demo@reqcore.com'
+        }
+        return email
+      })(),
       /** Public URL for hosted plan upsell CTA shown in preview mode modals */
       hostedPlanUrl: process.env.NUXT_PUBLIC_HOSTED_PLAN_URL || 'https://reqcore.com',
       /** Public live-demo secret used to prefill sign-in */


### PR DESCRIPTION
## Summary

- What does this PR change?
- Why is this needed?

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Validation

- [ ] I tested locally
- [ ] I added/updated relevant documentation
- [ ] I verified multi-tenant scoping and auth behavior for affected API paths

## DCO

- [ ] All commits in this PR are signed off (`Signed-off-by`) via `git commit -s`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added runtime validation for email configuration to prevent stale domain usage, with automatic fallback to a default email address.

* **Chores**
  * Enhanced demo data seeding to automatically clean up legacy records before initialization, ensuring data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->