### PR TITLE
feat: implement applicant portal schema and authentication utilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,7 +103,12 @@ NUXT_PUBLIC_SITE_URL=http://localhost:3000
 # When configured, "Continue with <Provider>" buttons appear on the auth pages.
 
 # Google — Create credentials at https://console.cloud.google.com/apis/credentials
-# Redirect URI: https://yourdomain.com/api/auth/callback/google
+# Redirect URIs (add BOTH):
+#   https://yourdomain.com/api/auth/callback/google
+#   https://yourdomain.com/api/portal/auth/google/callback
+# For local dev, also add:
+#   http://localhost:3000/api/auth/callback/google
+#   http://localhost:3000/api/portal/auth/google/callback
 # AUTH_GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 # AUTH_GOOGLE_CLIENT_SECRET=GOCSPX-your-google-client-secret
 

--- a/app/components/portal/InterviewCard.vue
+++ b/app/components/portal/InterviewCard.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { Calendar, Clock, MapPin, Video, Phone, Users, Code, FileText } from 'lucide-vue-next'
+
+interface Interview {
+  id: string
+  title: string
+  type: string
+  status: string
+  scheduledAt: string | Date
+  duration: number
+  location: string | null
+  timezone: string
+  candidateResponse: string
+}
+
+const props = defineProps<{
+  interview: Interview
+}>()
+
+function getTypeIcon(type: string) {
+  if (type.includes('Video')) return Video
+  if (type.includes('Phone')) return Phone
+  if (type.includes('Panel')) return Users
+  if (type.includes('Technical')) return Code
+  if (type.includes('Take-Home')) return FileText
+  return Calendar
+}
+
+function formatDateTime(date: string | Date, tz: string): string {
+  return new Date(date).toLocaleString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: tz !== 'UTC' ? tz : undefined,
+  })
+}
+
+const responseLabel = computed(() => {
+  const map: Record<string, { text: string; color: string }> = {
+    pending: { text: 'Awaiting your response', color: 'text-warning-600 dark:text-warning-400' },
+    accepted: { text: 'Accepted', color: 'text-success-600 dark:text-success-400' },
+    declined: { text: 'Declined', color: 'text-danger-600 dark:text-danger-400' },
+    tentative: { text: 'Tentative', color: 'text-surface-500' },
+  }
+  return map[props.interview.candidateResponse] ?? { text: props.interview.candidateResponse, color: 'text-surface-500' }
+})
+</script>
+
+<template>
+  <div class="rounded-xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 p-4 sm:p-5 transition-all hover:shadow-md hover:border-brand-200 dark:hover:border-brand-800">
+    <div class="flex items-start gap-3">
+      <!-- Type icon -->
+      <div class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-brand-50 dark:bg-brand-900/30 text-brand-500">
+        <component :is="getTypeIcon(interview.type)" class="size-5" />
+      </div>
+
+      <div class="min-w-0 flex-1">
+        <!-- Title & type -->
+        <div class="flex items-center justify-between gap-2">
+          <h3 class="text-sm font-semibold text-surface-900 dark:text-surface-100 truncate">
+            {{ interview.title }}
+          </h3>
+          <span class="shrink-0 rounded-full px-2 py-0.5 text-xs font-medium bg-surface-100 dark:bg-surface-800 text-surface-600 dark:text-surface-400">
+            {{ interview.type }}
+          </span>
+        </div>
+
+        <!-- Date & time -->
+        <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm text-surface-500 dark:text-surface-400">
+          <span class="flex items-center gap-1.5">
+            <Calendar class="size-3.5" />
+            {{ formatDateTime(interview.scheduledAt, interview.timezone) }}
+          </span>
+          <span class="flex items-center gap-1.5">
+            <Clock class="size-3.5" />
+            {{ interview.duration }} min
+          </span>
+          <span v-if="interview.location" class="flex items-center gap-1.5">
+            <MapPin class="size-3.5" />
+            {{ interview.location }}
+          </span>
+        </div>
+
+        <!-- Response status -->
+        <div class="mt-2">
+          <span class="text-xs font-medium" :class="responseLabel.color">
+            {{ responseLabel.text }}
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/components/portal/PipelineProgress.vue
+++ b/app/components/portal/PipelineProgress.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { CheckCircle, Circle, Clock, XCircle } from 'lucide-vue-next'
+
+interface PipelineStage {
+  key: string
+  label: string
+  description: string
+  status: 'completed' | 'current' | 'upcoming' | 'inactive'
+}
+
+const props = defineProps<{
+  stages: PipelineStage[]
+  isRejected: boolean
+}>()
+
+function getStageIcon(status: string) {
+  switch (status) {
+    case 'completed': return CheckCircle
+    case 'current': return Clock
+    default: return Circle
+  }
+}
+
+/** Stage-specific colors matching the pipeline status badge palette. */
+function getStageColor(key: string) {
+  const map: Record<string, {
+    node: string
+    current: string
+    line: string
+    label: string
+    currentLabel: string
+    pulse: string
+  }> = {
+    new: {
+      node: 'bg-brand-500 text-white shadow-sm shadow-brand-500/25',
+      current: 'bg-brand-500 text-white shadow-md shadow-brand-500/40 ring-4 ring-brand-100 dark:ring-brand-900/50',
+      line: 'bg-brand-500',
+      label: 'text-brand-700 dark:text-brand-300',
+      currentLabel: 'text-brand-600 dark:text-brand-400',
+      pulse: 'bg-brand-500/40',
+    },
+    screening: {
+      node: 'bg-accent-500 text-white shadow-sm shadow-accent-500/25',
+      current: 'bg-accent-500 text-white shadow-md shadow-accent-500/40 ring-4 ring-accent-100 dark:ring-accent-900/50',
+      line: 'bg-accent-500',
+      label: 'text-accent-700 dark:text-accent-300',
+      currentLabel: 'text-accent-600 dark:text-accent-400',
+      pulse: 'bg-accent-500/40',
+    },
+    interview: {
+      node: 'bg-brand-500 text-white shadow-sm shadow-brand-500/25',
+      current: 'bg-brand-500 text-white shadow-md shadow-brand-500/40 ring-4 ring-brand-100 dark:ring-brand-900/50',
+      line: 'bg-brand-500',
+      label: 'text-brand-700 dark:text-brand-300',
+      currentLabel: 'text-brand-600 dark:text-brand-400',
+      pulse: 'bg-brand-500/40',
+    },
+    offer: {
+      node: 'bg-success-500 text-white shadow-sm shadow-success-500/25',
+      current: 'bg-success-500 text-white shadow-md shadow-success-500/40 ring-4 ring-success-100 dark:ring-success-900/50',
+      line: 'bg-success-500',
+      label: 'text-success-700 dark:text-success-300',
+      currentLabel: 'text-success-600 dark:text-success-400',
+      pulse: 'bg-success-500/40',
+    },
+    hired: {
+      node: 'bg-success-500 text-white shadow-sm shadow-success-500/25',
+      current: 'bg-success-500 text-white shadow-md shadow-success-500/40 ring-4 ring-success-100 dark:ring-success-900/50',
+      line: 'bg-success-500',
+      label: 'text-success-700 dark:text-success-300',
+      currentLabel: 'text-success-600 dark:text-success-400',
+      pulse: 'bg-success-500/40',
+    },
+  }
+  return map[key] ?? map.new!
+}
+
+/** Connector line color: use the color of the stage it leads INTO. */
+function getConnectorClass(stage: PipelineStage) {
+  if (stage.status === 'completed' || stage.status === 'current') {
+    return getStageColor(stage.key).line
+  }
+  return props.isRejected
+    ? 'bg-danger-200 dark:bg-danger-900'
+    : 'bg-surface-200 dark:bg-surface-700'
+}
+</script>
+
+<template>
+  <div class="relative">
+    <!-- Rejected banner -->
+    <div
+      v-if="isRejected"
+      class="mb-4 rounded-lg border border-danger-200 dark:border-danger-900 bg-danger-50 dark:bg-danger-950/30 px-4 py-3 flex items-center gap-3"
+    >
+      <XCircle class="size-5 text-danger-500 shrink-0" />
+      <div>
+        <p class="text-sm font-medium text-danger-700 dark:text-danger-300">Application not selected</p>
+        <p class="text-xs text-danger-600 dark:text-danger-400 mt-0.5">The team has decided not to move forward at this time. Don't be discouraged — keep applying!</p>
+      </div>
+    </div>
+
+    <!-- Pipeline steps — full-width, responsive grid -->
+    <div class="grid w-full" :style="{ gridTemplateColumns: `repeat(${stages.length * 2 - 1}, minmax(0, 1fr))` }">
+      <template v-for="(stage, index) in stages" :key="stage.key">
+        <!-- Connector line -->
+        <div
+          v-if="index > 0"
+          class="flex items-center self-start pt-4"
+        >
+          <div
+            class="h-0.5 w-full transition-colors duration-300"
+            :class="getConnectorClass(stage)"
+          />
+        </div>
+
+        <!-- Stage node -->
+        <div class="flex flex-col items-center group">
+          <div
+            class="relative size-8 sm:size-9 rounded-full flex items-center justify-center transition-all duration-300"
+            :class="[
+              stage.status === 'completed' && getStageColor(stage.key).node,
+              stage.status === 'current' && getStageColor(stage.key).current,
+              stage.status === 'upcoming' && 'bg-surface-100 dark:bg-surface-800 text-surface-400 dark:text-surface-500',
+              stage.status === 'inactive' && 'bg-surface-100 dark:bg-surface-800 text-surface-300 dark:text-surface-600',
+            ]"
+          >
+            <component :is="getStageIcon(stage.status)" class="size-4" />
+
+            <!-- Pulse animation for current stage -->
+            <span
+              v-if="stage.status === 'current'"
+              class="absolute inset-0 rounded-full animate-ping"
+              :class="getStageColor(stage.key).pulse"
+            />
+          </div>
+
+          <span
+            class="mt-2 text-[11px] sm:text-xs font-medium text-center leading-tight"
+            :class="[
+              stage.status === 'current' && getStageColor(stage.key).currentLabel,
+              stage.status === 'completed' && getStageColor(stage.key).label,
+              (stage.status === 'upcoming' || stage.status === 'inactive') && 'text-surface-400 dark:text-surface-500',
+            ]"
+          >
+            {{ stage.label }}
+          </span>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/app/components/portal/StatusBadge.vue
+++ b/app/components/portal/StatusBadge.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+const props = defineProps<{
+  status: string
+}>()
+
+const statusConfig = computed(() => {
+  const map: Record<string, { label: string; color: string; bg: string }> = {
+    new: {
+      label: 'Applied',
+      color: 'text-brand-700 dark:text-brand-300',
+      bg: 'bg-brand-50 dark:bg-brand-900/30 border-brand-200 dark:border-brand-800',
+    },
+    screening: {
+      label: 'Under Review',
+      color: 'text-accent-700 dark:text-accent-300',
+      bg: 'bg-accent-50 dark:bg-accent-900/30 border-accent-200 dark:border-accent-800',
+    },
+    interview: {
+      label: 'Interview',
+      color: 'text-brand-700 dark:text-brand-300',
+      bg: 'bg-brand-50 dark:bg-brand-900/30 border-brand-200 dark:border-brand-800',
+    },
+    offer: {
+      label: 'Offer',
+      color: 'text-success-700 dark:text-success-300',
+      bg: 'bg-success-50 dark:bg-success-900/30 border-success-200 dark:border-success-800',
+    },
+    hired: {
+      label: 'Hired',
+      color: 'text-success-700 dark:text-success-300',
+      bg: 'bg-success-50 dark:bg-success-900/30 border-success-200 dark:border-success-800',
+    },
+    rejected: {
+      label: 'Not Selected',
+      color: 'text-danger-700 dark:text-danger-300',
+      bg: 'bg-danger-50 dark:bg-danger-900/30 border-danger-200 dark:border-danger-800',
+    },
+  }
+  return map[props.status] ?? { label: props.status, color: 'text-surface-600', bg: 'bg-surface-100 border-surface-200' }
+})
+</script>
+
+<template>
+  <span
+    class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"
+    :class="[statusConfig.color, statusConfig.bg]"
+  >
+    {{ statusConfig.label }}
+  </span>
+</template>

--- a/app/components/portal/StatusTimeline.vue
+++ b/app/components/portal/StatusTimeline.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+import {
+  FileText,
+  GitCommitHorizontal,
+  Calendar,
+  ArrowRight,
+  CheckCircle2,
+  XCircle,
+  Star,
+  UserCheck,
+  Eye,
+} from 'lucide-vue-next'
+
+interface TimelineEntry {
+  id: string
+  type: 'status_change' | 'interview'
+  title: string
+  description: string
+  date: string | Date
+}
+
+const props = defineProps<{
+  entries: TimelineEntry[]
+}>()
+
+function getIcon(entry: TimelineEntry) {
+  if (entry.type === 'interview') return Calendar
+  if (entry.title.includes('Hired')) return Star
+  if (entry.title.includes('Not Moving')) return XCircle
+  if (entry.title.includes('Offer')) return UserCheck
+  if (entry.title.includes('Viewed')) return Eye
+  if (entry.title.includes('Submitted')) return FileText
+  return ArrowRight
+}
+
+function getIconColor(entry: TimelineEntry) {
+  if (entry.title.includes('Hired')) return 'text-success-500 bg-success-50 dark:bg-success-900/30'
+  if (entry.title.includes('Not Moving')) return 'text-danger-500 bg-danger-50 dark:bg-danger-900/30'
+  if (entry.title.includes('Offer')) return 'text-accent-500 bg-accent-50 dark:bg-accent-900/30'
+  if (entry.title.includes('Viewed')) return 'text-success-500 bg-success-50 dark:bg-success-900/30'
+  if (entry.type === 'interview') return 'text-brand-500 bg-brand-50 dark:bg-brand-900/30'
+  return 'text-surface-500 bg-surface-100 dark:bg-surface-800'
+}
+
+function formatDate(date: string | Date): string {
+  return new Date(date).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+function formatTime(date: string | Date): string {
+  return new Date(date).toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function formatDateTime(date: string | Date): string {
+  return new Date(date).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+</script>
+
+<template>
+  <div class="flow-root">
+    <ul class="-mb-8">
+      <li v-for="(entry, index) in entries" :key="entry.id" class="relative pb-8">
+        <!-- Connector line -->
+        <span
+          v-if="index < entries.length - 1"
+          class="absolute left-4 top-8 -ml-px h-full w-0.5 bg-surface-200 dark:bg-surface-700"
+        />
+
+        <div class="relative flex items-start gap-3">
+          <!-- Icon -->
+          <div
+            class="relative flex size-8 shrink-0 items-center justify-center rounded-full"
+            :class="getIconColor(entry)"
+          >
+            <component :is="getIcon(entry)" class="size-4" />
+          </div>
+
+          <!-- Content -->
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center justify-between gap-2">
+              <p class="text-sm font-medium text-surface-900 dark:text-surface-100">
+                {{ entry.title }}
+              </p>
+              <time
+                class="shrink-0 text-xs text-surface-400 dark:text-surface-500 tabular-nums"
+                :title="formatDateTime(entry.date)"
+              >
+                {{ formatDate(entry.date) }} at {{ formatTime(entry.date) }}
+              </time>
+            </div>
+            <p class="mt-0.5 text-sm text-surface-500 dark:text-surface-400">
+              {{ entry.description }}
+            </p>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/app/layouts/portal.vue
+++ b/app/layouts/portal.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+const config = useRuntimeConfig()
+</script>
+
+<template>
+  <div class="min-h-screen bg-surface-50 dark:bg-surface-950">
+    <!-- Premium portal header -->
+    <header class="sticky top-0 z-30 border-b border-surface-200 dark:border-surface-800 bg-white/80 dark:bg-surface-900/80 backdrop-blur-xl">
+      <div class="mx-auto max-w-5xl px-4 sm:px-6 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <div class="flex items-center gap-2">
+            <div class="size-8 rounded-lg bg-gradient-to-br from-brand-500 to-brand-600 flex items-center justify-center">
+              <svg class="size-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+            </div>
+            <div>
+              <span class="text-sm font-semibold text-surface-900 dark:text-surface-100">Application Portal</span>
+              <span class="hidden sm:inline text-xs text-surface-400 dark:text-surface-500 ml-2">Powered by Reqcore</span>
+            </div>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <LanguageSwitcher />
+        </div>
+      </div>
+    </header>
+
+    <!-- Content -->
+    <main class="mx-auto max-w-5xl px-4 sm:px-6 py-6 sm:py-8">
+      <slot />
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-surface-200 dark:border-surface-800 mt-16">
+      <div class="mx-auto max-w-5xl px-4 sm:px-6 py-6 flex items-center justify-between">
+        <p class="text-xs text-surface-400">
+          &copy; {{ new Date().getFullYear() }} Applicant Portal
+        </p>
+        <p class="text-xs text-surface-400">
+          Powered by <a :href="config.public.marketingUrl ?? 'https://reqcore.com'" class="underline hover:text-surface-600 dark:hover:text-surface-300" target="_blank" rel="noopener">Reqcore</a>
+        </p>
+      </div>
+    </footer>
+  </div>
+</template>

--- a/app/pages/jobs/[slug]/apply.vue
+++ b/app/pages/jobs/[slug]/apply.vue
@@ -163,6 +163,8 @@ async function handleSubmit() {
     const hasAnyFiles = Object.keys(fileUploads.value).length > 0
       || !!resumeFile.value
 
+    let result: { success: boolean; portalToken?: string | null } | undefined
+
     if (hasAnyFiles) {
       // Use FormData when files are present
       const formData = new FormData()
@@ -201,13 +203,13 @@ async function handleSubmit() {
       if (utmTerm) formData.append('utmTerm', utmTerm)
       if (utmContent) formData.append('utmContent', utmContent)
 
-      await $fetch(`/api/public/jobs/${jobSlug}/apply`, {
+      result = await $fetch<{ success: boolean; portalToken?: string | null }>(`/api/public/jobs/${jobSlug}/apply`, {
         method: 'POST',
         body: formData,
       })
     } else {
       // No files — use JSON as before
-      await $fetch(`/api/public/jobs/${jobSlug}/apply`, {
+      result = await $fetch<{ success: boolean; portalToken?: string | null }>(`/api/public/jobs/${jobSlug}/apply`, {
         method: 'POST',
         body: {
           firstName: form.value.firstName.trim(),
@@ -228,7 +230,13 @@ async function handleSubmit() {
     }
 
     track('application_submitted', { slug: jobSlug })
-    await navigateTo(`/jobs/${jobSlug}/confirmation`)
+    // Redirect directly to the portal dashboard if we have a token,
+    // otherwise fall back to the confirmation page
+    if (result?.portalToken) {
+      await navigateTo(`/portal/t/${result.portalToken}?fresh=1`)
+    } else {
+      await navigateTo({ path: `/jobs/${jobSlug}/confirmation` })
+    }
   } catch (err: any) {
     const message = err.data?.statusMessage ?? 'Something went wrong. Please try again.'
     submitError.value = message

--- a/app/pages/jobs/[slug]/confirmation.vue
+++ b/app/pages/jobs/[slug]/confirmation.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { CheckCircle } from 'lucide-vue-next'
+import { CheckCircle, ExternalLink, Clipboard, Check } from 'lucide-vue-next'
 
 definePageMeta({
   layout: 'public',
@@ -7,6 +7,7 @@ definePageMeta({
 
 const route = useRoute()
 const jobSlug = route.params.slug as string
+const portalToken = computed(() => route.query.pt as string | undefined)
 const { track } = useTrack()
 
 onMounted(() => track('application_confirmed', { slug: jobSlug }))
@@ -20,6 +21,29 @@ useSeoMeta({
   title: 'Application Submitted — Reqcore',
   robots: 'noindex, nofollow',
 })
+
+// Build portal URL
+const config = useRuntimeConfig()
+const portalUrl = computed(() => {
+  if (!portalToken.value) return null
+  // Use current origin for the portal link
+  if (import.meta.client) {
+    return `${window.location.origin}/portal/t/${portalToken.value}`
+  }
+  return `/portal/t/${portalToken.value}`
+})
+
+const copied = ref(false)
+async function copyLink() {
+  if (!portalUrl.value) return
+  try {
+    await navigator.clipboard.writeText(portalUrl.value)
+    copied.value = true
+    setTimeout(() => { copied.value = false }, 2000)
+  } catch {
+    // Fallback: select text
+  }
+}
 </script>
 
 <template>
@@ -42,6 +66,38 @@ useSeoMeta({
     <p class="text-sm text-surface-400 max-w-md mx-auto mb-8">
       Your application has been received. The hiring team will review it and get back to you if there&rsquo;s a match.
     </p>
+
+    <!-- Portal link card -->
+    <div
+      v-if="portalUrl"
+      class="mx-auto max-w-lg mb-8 rounded-2xl border border-brand-200 dark:border-brand-800 bg-brand-50/50 dark:bg-brand-950/20 p-5 text-left"
+    >
+      <h3 class="text-sm font-semibold text-brand-700 dark:text-brand-300 mb-1">Track Your Application</h3>
+      <p class="text-sm text-brand-600 dark:text-brand-400 mb-3">
+        Bookmark this link to check your application status anytime. You can also sign in with Google to track all applications.
+      </p>
+      <div class="flex items-center gap-2">
+        <div class="flex-1 rounded-lg border border-brand-200 dark:border-brand-700 bg-white dark:bg-surface-800 px-3 py-2 text-sm text-surface-600 dark:text-surface-300 truncate font-mono">
+          {{ portalUrl }}
+        </div>
+        <button
+          class="shrink-0 inline-flex items-center gap-1.5 rounded-lg bg-brand-600 px-3 py-2 text-sm font-medium text-white hover:bg-brand-700 transition-colors"
+          @click="copyLink"
+        >
+          <component :is="copied ? Check : Clipboard" class="size-4" />
+          {{ copied ? 'Copied!' : 'Copy' }}
+        </button>
+      </div>
+      <div class="mt-3 flex items-center gap-3">
+        <NuxtLink
+          :to="portalUrl"
+          class="inline-flex items-center gap-1.5 text-sm font-medium text-brand-600 dark:text-brand-400 hover:text-brand-700 dark:hover:text-brand-300 transition-colors"
+        >
+          <ExternalLink class="size-3.5" />
+          View your dashboard now
+        </NuxtLink>
+      </div>
+    </div>
 
     <div class="flex flex-col sm:flex-row items-center justify-center gap-3">
       <NuxtLink

--- a/app/pages/portal/applications/[id].vue
+++ b/app/pages/portal/applications/[id].vue
@@ -1,0 +1,223 @@
+<script setup lang="ts">
+import {
+  Building2,
+  MapPin,
+  Briefcase,
+  Calendar,
+  FileText,
+  Clock,
+  ChevronLeft,
+  Shield,
+  Globe,
+} from 'lucide-vue-next'
+
+definePageMeta({
+  layout: 'portal',
+})
+
+const route = useRoute()
+const applicationId = computed(() => route.params.id as string)
+
+// Check session
+const { data: sessionData } = await useFetch('/api/portal/auth/session')
+if (!sessionData.value?.authenticated) {
+  await navigateTo('/portal/auth/sign-in')
+}
+
+const { data, error, status } = await useFetch(`/api/portal/applications/${applicationId.value}`, {
+  key: `portal-app-${applicationId.value}`,
+  headers: useRequestHeaders(['cookie']),
+})
+
+useHead({
+  title: data.value ? `${data.value.job.title} — Application Status` : 'Application Portal',
+  meta: [
+    { name: 'robots', content: 'noindex, nofollow' },
+  ],
+})
+
+function formatDate(date: string | Date): string {
+  return new Date(date).toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+function getRelativeTime(date: string | Date): string {
+  const now = new Date()
+  const d = new Date(date)
+  const diff = now.getTime() - d.getTime()
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24))
+
+  if (days === 0) return 'Today'
+  if (days === 1) return 'Yesterday'
+  if (days < 7) return `${days} days ago`
+  if (days < 30) return `${Math.floor(days / 7)} weeks ago`
+  return `${Math.floor(days / 30)} months ago`
+}
+</script>
+
+<template>
+  <!-- Back nav -->
+  <div class="mb-4">
+    <NuxtLink
+      to="/portal"
+      class="inline-flex items-center gap-1 text-sm text-surface-500 dark:text-surface-400 hover:text-brand-600 dark:hover:text-brand-400 transition-colors"
+    >
+      <ChevronLeft class="size-4" />
+      Back to all applications
+    </NuxtLink>
+  </div>
+
+  <!-- Error state -->
+  <div v-if="error" class="flex flex-col items-center justify-center py-20 text-center">
+    <div class="size-16 rounded-full bg-danger-50 dark:bg-danger-900/30 flex items-center justify-center mb-4">
+      <Shield class="size-8 text-danger-500" />
+    </div>
+    <h1 class="text-xl font-bold text-surface-900 dark:text-surface-100">Application Not Found</h1>
+    <p class="mt-2 text-sm text-surface-500 dark:text-surface-400">
+      This application could not be loaded.
+    </p>
+    <NuxtLink
+      to="/portal"
+      class="mt-6 inline-flex items-center gap-2 rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-medium text-white shadow-sm hover:bg-brand-700 transition-colors"
+    >
+      Back to dashboard
+    </NuxtLink>
+  </div>
+
+  <!-- Loading state -->
+  <div v-else-if="status === 'pending'" class="flex items-center justify-center py-20">
+    <div class="animate-spin size-8 border-2 border-brand-500 border-t-transparent rounded-full" />
+  </div>
+
+  <!-- Dashboard content (same layout as token page) -->
+  <div v-else-if="data" class="space-y-6">
+    <!-- Header card -->
+    <div class="rounded-2xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 overflow-hidden">
+      <div class="h-1.5 bg-gradient-to-r from-brand-500 via-accent-500 to-brand-600" />
+      <div class="p-5 sm:p-6">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+          <div class="flex items-start gap-4">
+            <div class="size-12 rounded-xl bg-surface-100 dark:bg-surface-800 flex items-center justify-center shrink-0 overflow-hidden">
+              <img
+                v-if="data.organization.logo"
+                :src="data.organization.logo"
+                :alt="data.organization.name"
+                class="size-full object-cover"
+              />
+              <Building2 v-else class="size-6 text-surface-400" />
+            </div>
+            <div>
+              <h1 class="text-lg sm:text-xl font-bold text-surface-900 dark:text-surface-100">
+                {{ data.job.title }}
+              </h1>
+              <div class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-surface-500 dark:text-surface-400">
+                <span class="flex items-center gap-1">
+                  <Building2 class="size-3.5" />
+                  {{ data.organization.name }}
+                </span>
+                <span v-if="data.job.location" class="flex items-center gap-1">
+                  <MapPin class="size-3.5" />
+                  {{ data.job.location }}
+                </span>
+                <span class="flex items-center gap-1">
+                  <Briefcase class="size-3.5" />
+                  {{ data.job.type }}
+                </span>
+                <span v-if="data.job.remoteStatus" class="flex items-center gap-1">
+                  <Globe class="size-3.5" />
+                  {{ data.job.remoteStatus }}
+                </span>
+              </div>
+            </div>
+          </div>
+          <PortalStatusBadge :status="data.application.status" />
+        </div>
+        <div class="mt-4 pt-4 border-t border-surface-100 dark:border-surface-800 flex items-center justify-between text-sm text-surface-500 dark:text-surface-400">
+          <span class="flex items-center gap-1.5">
+            <Calendar class="size-3.5" />
+            Applied {{ formatDate(data.application.appliedAt) }}
+          </span>
+          <span v-if="data.application.lastUpdated" class="flex items-center gap-1.5">
+            <Clock class="size-3.5" />
+            Updated {{ getRelativeTime(data.application.lastUpdated) }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Pipeline Progress -->
+    <div class="rounded-2xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 p-5 sm:p-6">
+      <h2 class="text-sm font-semibold text-surface-900 dark:text-surface-100 mb-4">Application Progress</h2>
+      <PortalPipelineProgress :stages="data.pipeline" :is-rejected="data.application.isRejected" />
+    </div>
+
+    <!-- Interviews + Documents side by side -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div class="rounded-2xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 p-5 sm:p-6">
+        <h2 class="text-sm font-semibold text-surface-900 dark:text-surface-100 mb-4 flex items-center gap-2">
+          <Calendar class="size-4 text-brand-500" />
+          Upcoming Interviews
+        </h2>
+        <div v-if="data.upcomingInterviews.length > 0" class="space-y-3">
+          <PortalInterviewCard v-for="iv in data.upcomingInterviews" :key="iv.id" :interview="iv" />
+        </div>
+        <div v-else class="text-center py-8">
+          <Calendar class="size-8 mx-auto text-surface-300 dark:text-surface-600 mb-2" />
+          <p class="text-sm text-surface-400 dark:text-surface-500">No upcoming interviews</p>
+        </div>
+        <div v-if="data.pastInterviews.length > 0" class="mt-6 pt-4 border-t border-surface-100 dark:border-surface-800">
+          <h3 class="text-xs font-medium text-surface-400 dark:text-surface-500 uppercase tracking-wider mb-3">Past Interviews</h3>
+          <div class="space-y-2">
+            <PortalInterviewCard v-for="iv in data.pastInterviews" :key="iv.id" :interview="iv" />
+          </div>
+        </div>
+      </div>
+
+      <div class="rounded-2xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 p-5 sm:p-6">
+        <h2 class="text-sm font-semibold text-surface-900 dark:text-surface-100 mb-4 flex items-center gap-2">
+          <FileText class="size-4 text-brand-500" />
+          Your Documents
+        </h2>
+        <div v-if="data.documents.length > 0" class="space-y-2">
+          <div
+            v-for="doc in data.documents"
+            :key="doc.id"
+            class="flex items-center gap-3 rounded-lg border border-surface-100 dark:border-surface-800 bg-surface-50 dark:bg-surface-800/50 px-3 py-2.5"
+          >
+            <div class="size-8 rounded-lg bg-brand-50 dark:bg-brand-900/30 flex items-center justify-center shrink-0">
+              <FileText class="size-4 text-brand-500" />
+            </div>
+            <div class="min-w-0 flex-1">
+              <p class="text-sm font-medium text-surface-700 dark:text-surface-200 truncate">{{ doc.filename }}</p>
+              <p class="text-xs text-surface-400 dark:text-surface-500">
+                {{ doc.type === 'resume' ? 'Resume' : doc.type === 'cover_letter' ? 'Cover Letter' : 'Document' }}
+              </p>
+            </div>
+          </div>
+        </div>
+        <div v-else class="text-center py-8">
+          <FileText class="size-8 mx-auto text-surface-300 dark:text-surface-600 mb-2" />
+          <p class="text-sm text-surface-400 dark:text-surface-500">No documents uploaded</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Timeline -->
+    <div class="rounded-2xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 p-5 sm:p-6">
+      <h2 class="text-sm font-semibold text-surface-900 dark:text-surface-100 mb-4 flex items-center gap-2">
+        <Clock class="size-4 text-brand-500" />
+        Activity Timeline
+      </h2>
+      <div v-if="data.timeline.length > 0">
+        <PortalStatusTimeline :entries="data.timeline" />
+      </div>
+      <div v-else class="text-center py-8">
+        <Clock class="size-8 mx-auto text-surface-300 dark:text-surface-600 mb-2" />
+        <p class="text-sm text-surface-400 dark:text-surface-500">No activity yet</p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/pages/portal/auth/sign-in.vue
+++ b/app/pages/portal/auth/sign-in.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { LogIn, Shield, FileSearch } from 'lucide-vue-next'
+
+definePageMeta({
+  layout: 'portal',
+})
+
+const route = useRoute()
+const error = computed(() => route.query.error as string | undefined)
+
+// Check if already authenticated
+const { data: sessionData } = await useFetch('/api/portal/auth/session')
+if (sessionData.value?.authenticated) {
+  await navigateTo('/portal')
+}
+
+useHead({
+  title: 'Sign In — Application Portal',
+  meta: [
+    { name: 'robots', content: 'noindex, nofollow' },
+  ],
+})
+</script>
+
+<template>
+  <div class="flex flex-col items-center justify-center min-h-[60vh]">
+    <div class="w-full max-w-md">
+      <!-- Header -->
+      <div class="text-center mb-8">
+        <div class="size-16 rounded-2xl bg-gradient-to-br from-brand-500 to-brand-600 flex items-center justify-center mx-auto mb-4 shadow-lg shadow-brand-500/20">
+          <FileSearch class="size-8 text-white" />
+        </div>
+        <h1 class="text-2xl font-bold text-surface-900 dark:text-surface-100">Application Portal</h1>
+        <p class="mt-2 text-sm text-surface-500 dark:text-surface-400">
+          Sign in to track all your job applications in one place
+        </p>
+      </div>
+
+      <!-- Error message -->
+      <div
+        v-if="error"
+        class="mb-4 rounded-lg border border-danger-200 dark:border-danger-800 bg-danger-50 dark:bg-danger-950/30 px-4 py-3 text-sm text-danger-700 dark:text-danger-300"
+      >
+        <template v-if="error === 'oauth_denied'">
+          You cancelled the sign-in process. Please try again.
+        </template>
+        <template v-else>
+          Something went wrong. Please try again.
+        </template>
+      </div>
+
+      <!-- Sign in card -->
+      <div class="rounded-2xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 p-6 sm:p-8">
+        <NuxtLink
+          to="/api/portal/auth/google"
+          class="flex w-full items-center justify-center gap-3 rounded-xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 px-4 py-3 text-sm font-medium text-surface-700 dark:text-surface-200 shadow-sm hover:bg-surface-50 dark:hover:bg-surface-700 hover:shadow-md transition-all"
+          external
+        >
+          <svg class="size-5" viewBox="0 0 24 24"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/></svg>
+          Continue with Google
+        </NuxtLink>
+
+        <div class="mt-6 flex items-center gap-3">
+          <div class="flex-1 h-px bg-surface-200 dark:bg-surface-700" />
+          <span class="text-xs text-surface-400 dark:text-surface-500">or</span>
+          <div class="flex-1 h-px bg-surface-200 dark:bg-surface-700" />
+        </div>
+
+        <div class="mt-6 text-center">
+          <p class="text-sm text-surface-500 dark:text-surface-400">
+            Have an access link? Paste it in your browser to view your application directly.
+          </p>
+        </div>
+      </div>
+
+      <!-- Features -->
+      <div class="mt-8 grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div class="flex items-start gap-3 rounded-xl bg-surface-50 dark:bg-surface-900/50 border border-surface-100 dark:border-surface-800 p-4">
+          <Shield class="size-5 text-brand-500 shrink-0 mt-0.5" />
+          <div>
+            <p class="text-sm font-medium text-surface-700 dark:text-surface-200">Read-only access</p>
+            <p class="text-xs text-surface-500 dark:text-surface-400 mt-0.5">Your data is safe — view only, no changes</p>
+          </div>
+        </div>
+        <div class="flex items-start gap-3 rounded-xl bg-surface-50 dark:bg-surface-900/50 border border-surface-100 dark:border-surface-800 p-4">
+          <FileSearch class="size-5 text-brand-500 shrink-0 mt-0.5" />
+          <div>
+            <p class="text-sm font-medium text-surface-700 dark:text-surface-200">All applications</p>
+            <p class="text-xs text-surface-500 dark:text-surface-400 mt-0.5">Track every job you've applied to</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/pages/portal/index.vue
+++ b/app/pages/portal/index.vue
@@ -1,0 +1,217 @@
+<script setup lang="ts">
+import {
+  Building2,
+  MapPin,
+  Briefcase,
+  Calendar,
+  ChevronRight,
+  LogOut,
+  User,
+  Inbox,
+} from 'lucide-vue-next'
+
+definePageMeta({
+  layout: 'portal',
+})
+
+const { data: sessionData, error: sessionError } = await useFetch('/api/portal/auth/session')
+
+// Redirect to sign-in if not authenticated
+if (!sessionData.value?.authenticated) {
+  await navigateTo('/portal/auth/sign-in')
+}
+
+const { data, error, status, refresh } = await useFetch('/api/portal/dashboard', {
+  key: 'portal-dashboard',
+  headers: useRequestHeaders(['cookie']),
+})
+
+const signingOut = ref(false)
+
+async function signOut() {
+  signingOut.value = true
+  try {
+    await $fetch('/api/portal/auth/sign-out', { method: 'POST' })
+    await navigateTo('/portal/auth/sign-in')
+  } finally {
+    signingOut.value = false
+  }
+}
+
+// SEO
+useHead({
+  title: 'My Applications — Application Portal',
+  meta: [
+    { name: 'robots', content: 'noindex, nofollow' },
+  ],
+})
+
+function formatDate(date: string | Date): string {
+  return new Date(date).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+function getRelativeTime(date: string | Date): string {
+  const now = new Date()
+  const d = new Date(date)
+  const diff = now.getTime() - d.getTime()
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24))
+
+  if (days === 0) return 'Today'
+  if (days === 1) return 'Yesterday'
+  if (days < 7) return `${days} days ago`
+  if (days < 30) return `${Math.floor(days / 7)} weeks ago`
+  return `${Math.floor(days / 30)} months ago`
+}
+</script>
+
+<template>
+  <div>
+    <!-- Auth header -->
+    <div v-if="data?.account" class="mb-6 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div class="size-10 rounded-full bg-surface-200 dark:bg-surface-700 overflow-hidden">
+          <img
+            v-if="data.account.image"
+            :src="data.account.image"
+            :alt="data.account.name ?? 'Profile'"
+            class="size-full object-cover"
+          />
+          <div v-else class="size-full flex items-center justify-center">
+            <User class="size-5 text-surface-400" />
+          </div>
+        </div>
+        <div>
+          <p class="text-sm font-semibold text-surface-900 dark:text-surface-100">
+            {{ data.account.name ?? 'Applicant' }}
+          </p>
+          <p class="text-xs text-surface-500 dark:text-surface-400">
+            {{ data.account.email }}
+          </p>
+        </div>
+      </div>
+      <button
+        class="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium text-surface-500 dark:text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors"
+        :disabled="signingOut"
+        @click="signOut"
+      >
+        <LogOut class="size-3.5" />
+        Sign out
+      </button>
+    </div>
+
+    <!-- Page title -->
+    <div class="mb-6">
+      <h1 class="text-xl font-bold text-surface-900 dark:text-surface-100">My Applications</h1>
+      <p class="mt-1 text-sm text-surface-500 dark:text-surface-400">
+        Track all your job applications in one place
+      </p>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="status === 'pending'" class="flex items-center justify-center py-20">
+      <div class="animate-spin size-8 border-2 border-brand-500 border-t-transparent rounded-full" />
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="text-center py-16">
+      <p class="text-sm text-danger-600 dark:text-danger-400">{{ error.data?.message || 'Failed to load applications' }}</p>
+      <button
+        class="mt-4 rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 transition-colors"
+        @click="refresh()"
+      >
+        Try again
+      </button>
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="!data?.applications?.length" class="text-center py-20">
+      <div class="size-16 rounded-full bg-surface-100 dark:bg-surface-800 flex items-center justify-center mx-auto mb-4">
+        <Inbox class="size-8 text-surface-300 dark:text-surface-600" />
+      </div>
+      <h2 class="text-lg font-semibold text-surface-900 dark:text-surface-100">No applications found</h2>
+      <p class="mt-2 text-sm text-surface-500 dark:text-surface-400 max-w-md mx-auto">
+        No applications were found for {{ data?.account?.email }}. Make sure you applied using this email address.
+      </p>
+    </div>
+
+    <!-- Application cards -->
+    <div v-else class="space-y-4">
+      <NuxtLink
+        v-for="app in data.applications"
+        :key="app.id"
+        :to="`/portal/applications/${app.id}`"
+        class="block rounded-2xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 p-5 transition-all hover:shadow-lg hover:border-brand-200 dark:hover:border-brand-800 hover:-translate-y-0.5 group"
+      >
+        <div class="flex items-start justify-between gap-4">
+          <div class="flex items-start gap-4 min-w-0">
+            <!-- Company logo -->
+            <div class="size-11 rounded-xl bg-surface-100 dark:bg-surface-800 flex items-center justify-center shrink-0 overflow-hidden">
+              <img
+                v-if="app.organization.logo"
+                :src="app.organization.logo"
+                :alt="app.organization.name"
+                class="size-full object-cover"
+              />
+              <Building2 v-else class="size-5 text-surface-400" />
+            </div>
+
+            <div class="min-w-0">
+              <h3 class="text-base font-semibold text-surface-900 dark:text-surface-100 truncate group-hover:text-brand-600 dark:group-hover:text-brand-400 transition-colors">
+                {{ app.job.title }}
+              </h3>
+              <div class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-surface-500 dark:text-surface-400">
+                <span class="flex items-center gap-1">
+                  <Building2 class="size-3.5" />
+                  {{ app.organization.name }}
+                </span>
+                <span v-if="app.job.location" class="flex items-center gap-1">
+                  <MapPin class="size-3.5" />
+                  {{ app.job.location }}
+                </span>
+                <span class="flex items-center gap-1">
+                  <Briefcase class="size-3.5" />
+                  {{ app.job.type }}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div class="flex items-center gap-2 shrink-0">
+            <PortalStatusBadge :status="app.status" />
+            <ChevronRight class="size-4 text-surface-300 dark:text-surface-600 group-hover:text-brand-500 transition-colors" />
+          </div>
+        </div>
+
+        <!-- Mini pipeline + meta -->
+        <div class="mt-4 pt-3 border-t border-surface-100 dark:border-surface-800 flex items-center justify-between">
+          <!-- Mini pipeline dots -->
+          <div class="flex items-center gap-1">
+            <div
+              v-for="stage in app.pipeline"
+              :key="stage.key"
+              class="size-2 rounded-full transition-colors"
+              :class="[
+                stage.status === 'completed' && 'bg-brand-500',
+                stage.status === 'current' && 'bg-brand-500 ring-2 ring-brand-200 dark:ring-brand-800',
+                stage.status === 'upcoming' && 'bg-surface-200 dark:bg-surface-700',
+                stage.status === 'inactive' && 'bg-surface-200 dark:bg-surface-700',
+              ]"
+            />
+          </div>
+
+          <div class="flex items-center gap-3 text-xs text-surface-400 dark:text-surface-500">
+            <span v-if="app.upcomingInterviewCount > 0" class="flex items-center gap-1 text-brand-600 dark:text-brand-400 font-medium">
+              <Calendar class="size-3" />
+              {{ app.upcomingInterviewCount }} upcoming
+            </span>
+            <span>Applied {{ getRelativeTime(app.appliedAt) }}</span>
+          </div>
+        </div>
+      </NuxtLink>
+    </div>
+  </div>
+</template>

--- a/app/pages/portal/t/[token].vue
+++ b/app/pages/portal/t/[token].vue
@@ -1,0 +1,385 @@
+<script setup lang="ts">
+import {
+  Building2,
+  MapPin,
+  Briefcase,
+  Calendar,
+  FileText,
+  Clock,
+  LogIn,
+  Shield,
+  Globe,
+  Bookmark,
+  RefreshCw,
+  Eye,
+} from 'lucide-vue-next'
+
+definePageMeta({
+  layout: 'portal',
+})
+
+const route = useRoute()
+const token = computed(() => route.params.token as string)
+
+// Whether the user just submitted their application (redirected with ?fresh=1)
+const isFreshSubmission = computed(() => route.query.fresh === '1')
+const bookmarkBannerDismissed = ref(false)
+
+const { data, error, status, refresh } = await useFetch(`/api/portal/token/${token.value}`, {
+  key: `portal-token-${token.value}`,
+})
+
+// Check if user has a portal session (for showing "save to account" prompt)
+const { data: sessionData } = await useFetch('/api/portal/auth/session')
+
+const isAuthenticated = computed(() => sessionData.value?.authenticated)
+
+// Auto-refresh polling every 30 seconds
+const isRefreshing = ref(false)
+let pollInterval: ReturnType<typeof setInterval> | null = null
+
+async function manualRefresh() {
+  isRefreshing.value = true
+  try {
+    await refresh()
+  } finally {
+    isRefreshing.value = false
+  }
+}
+
+onMounted(() => {
+  pollInterval = setInterval(async () => {
+    await refresh()
+  }, 30_000)
+})
+
+onUnmounted(() => {
+  if (pollInterval) clearInterval(pollInterval)
+})
+
+// SEO
+useHead({
+  title: data.value ? `${data.value.job.title} — Application Status` : 'Application Portal',
+  meta: [
+    { name: 'robots', content: 'noindex, nofollow' },
+  ],
+})
+
+function formatDate(date: string | Date): string {
+  return new Date(date).toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+function formatDateTime(date: string | Date): string {
+  return new Date(date).toLocaleString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function getRelativeTime(date: string | Date): string {
+  const now = new Date()
+  const d = new Date(date)
+  const diff = now.getTime() - d.getTime()
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24))
+
+  if (days === 0) return 'Today'
+  if (days === 1) return 'Yesterday'
+  if (days < 7) return `${days} days ago`
+  if (days < 30) return `${Math.floor(days / 7)} weeks ago`
+  if (days < 365) return `${Math.floor(days / 30)} months ago`
+  return `${Math.floor(days / 365)} years ago`
+}
+</script>
+
+<template>
+  <!-- Error state -->
+  <div v-if="error" class="flex flex-col items-center justify-center py-20 text-center">
+    <div class="size-16 rounded-full bg-danger-50 dark:bg-danger-900/30 flex items-center justify-center mb-4">
+      <Shield class="size-8 text-danger-500" />
+    </div>
+    <h1 class="text-xl font-bold text-surface-900 dark:text-surface-100">Access Link Invalid</h1>
+    <p class="mt-2 text-sm text-surface-500 dark:text-surface-400 max-w-md">
+      This link may have expired or is no longer valid. If you signed in with Google, you can access your applications from the portal dashboard.
+    </p>
+    <NuxtLink
+      to="/portal/auth/sign-in"
+      class="mt-6 inline-flex items-center gap-2 rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-medium text-white shadow-sm hover:bg-brand-700 transition-colors"
+    >
+      <LogIn class="size-4" />
+      Sign in to view your applications
+    </NuxtLink>
+  </div>
+
+  <!-- Loading state -->
+  <div v-else-if="status === 'pending'" class="flex items-center justify-center py-20">
+    <div class="animate-spin size-8 border-2 border-brand-500 border-t-transparent rounded-full" />
+  </div>
+
+  <!-- Dashboard content -->
+  <div v-else-if="data" class="space-y-6">
+    <!-- Bookmark banner (shown when arriving from fresh submission) -->
+    <div
+      v-if="isFreshSubmission && !bookmarkBannerDismissed"
+      class="rounded-xl border border-success-200 dark:border-success-800 bg-success-50/50 dark:bg-success-950/20 p-4 sm:p-5"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-start gap-3">
+          <div class="size-8 rounded-lg bg-success-100 dark:bg-success-900/40 flex items-center justify-center shrink-0">
+            <Bookmark class="size-4 text-success-600 dark:text-success-400" />
+          </div>
+          <div>
+            <h3 class="text-sm font-semibold text-success-700 dark:text-success-300">Application submitted successfully!</h3>
+            <p class="mt-0.5 text-sm text-success-600 dark:text-success-400">
+              Bookmark this page (<kbd class="rounded bg-success-100 dark:bg-success-900/50 px-1 py-0.5 text-xs font-mono">Ctrl+D</kbd>) to check your application status anytime. This is your personal dashboard — it updates automatically as your application progresses.
+            </p>
+          </div>
+        </div>
+        <button
+          class="shrink-0 text-success-400 hover:text-success-600 dark:hover:text-success-300 transition-colors"
+          @click="bookmarkBannerDismissed = true"
+        >
+          <span class="sr-only">Dismiss</span>
+          <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg>
+        </button>
+      </div>
+    </div>
+
+    <!-- Header card -->
+    <div class="rounded-2xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 overflow-hidden">
+      <!-- Gradient accent bar -->
+      <div class="h-1.5 bg-gradient-to-r from-brand-500 via-accent-500 to-brand-600" />
+
+      <div class="p-5 sm:p-6">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+          <div class="flex items-start gap-4">
+            <!-- Company logo -->
+            <div class="size-12 rounded-xl bg-surface-100 dark:bg-surface-800 flex items-center justify-center shrink-0 overflow-hidden">
+              <img
+                v-if="data.organization.logo"
+                :src="data.organization.logo"
+                :alt="data.organization.name"
+                class="size-full object-cover"
+              />
+              <Building2 v-else class="size-6 text-surface-400" />
+            </div>
+
+            <div>
+              <h1 class="text-lg sm:text-xl font-bold text-surface-900 dark:text-surface-100">
+                {{ data.job.title }}
+              </h1>
+              <div class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-surface-500 dark:text-surface-400">
+                <span class="flex items-center gap-1">
+                  <Building2 class="size-3.5" />
+                  {{ data.organization.name }}
+                </span>
+                <span v-if="data.job.location" class="flex items-center gap-1">
+                  <MapPin class="size-3.5" />
+                  {{ data.job.location }}
+                </span>
+                <span class="flex items-center gap-1">
+                  <Briefcase class="size-3.5" />
+                  {{ data.job.type }}
+                </span>
+                <span v-if="data.job.remoteStatus" class="flex items-center gap-1">
+                  <Globe class="size-3.5" />
+                  {{ data.job.remoteStatus }}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div class="flex items-center gap-3">
+            <button
+              class="inline-flex items-center gap-1.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 px-3 py-1.5 text-xs font-medium text-surface-600 dark:text-surface-300 hover:bg-surface-50 dark:hover:bg-surface-700 transition-colors"
+              :disabled="isRefreshing"
+              @click="manualRefresh"
+            >
+              <RefreshCw class="size-3.5" :class="{ 'animate-spin': isRefreshing }" />
+              {{ isRefreshing ? 'Refreshing...' : 'Refresh' }}
+            </button>
+            <PortalStatusBadge :status="data.application.status" />
+          </div>
+        </div>
+
+        <!-- Applied date & recruiter viewed -->
+        <div class="mt-4 pt-4 border-t border-surface-100 dark:border-surface-800 flex flex-col gap-2 text-sm text-surface-500 dark:text-surface-400">
+          <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-2">
+            <span class="flex items-center gap-1.5">
+              <Calendar class="size-3.5 shrink-0" />
+              <span class="truncate">Applied {{ formatDateTime(data.application.appliedAt) }}</span>
+              <span class="hidden sm:inline text-surface-300 dark:text-surface-600">&middot;</span>
+              <span class="hidden sm:inline">{{ getRelativeTime(data.application.appliedAt) }}</span>
+            </span>
+            <span v-if="data.application.lastUpdated" class="flex items-center gap-1.5">
+              <Clock class="size-3.5 shrink-0" />
+              <span class="truncate">Updated {{ formatDateTime(data.application.lastUpdated) }}</span>
+            </span>
+          </div>
+          <!-- Recruiter viewed indicator -->
+          <div v-if="data.application.viewedAt" class="flex items-center gap-1.5 text-xs text-success-600 dark:text-success-400">
+            <Eye class="size-3.5" />
+            Viewed by hiring team on {{ formatDateTime(data.application.viewedAt) }}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Save to account prompt (only if not signed in) -->
+    <div
+      v-if="!isAuthenticated"
+      class="rounded-xl border border-brand-200 dark:border-brand-800 bg-brand-50/50 dark:bg-brand-950/20 p-4 sm:p-5"
+    >
+      <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
+        <div>
+          <h3 class="text-sm font-semibold text-brand-700 dark:text-brand-300">Save this to your account</h3>
+          <p class="mt-0.5 text-sm text-brand-600 dark:text-brand-400">
+            Sign in with Google to track all your applications in one place — even across different companies.
+          </p>
+        </div>
+        <NuxtLink
+          :to="`/api/portal/auth/google?returnTo=/portal/t/${token}`"
+          class="shrink-0 inline-flex items-center gap-2 rounded-lg bg-white dark:bg-surface-800 border border-surface-200 dark:border-surface-700 px-4 py-2 text-sm font-medium text-surface-700 dark:text-surface-200 shadow-sm hover:bg-surface-50 dark:hover:bg-surface-700 transition-colors"
+          external
+        >
+          <svg class="size-4" viewBox="0 0 24 24"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/></svg>
+          Sign in with Google
+        </NuxtLink>
+      </div>
+    </div>
+
+    <!-- Pipeline Progress -->
+    <div class="rounded-2xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 p-5 sm:p-6">
+      <h2 class="text-sm font-semibold text-surface-900 dark:text-surface-100 mb-4">Application Progress</h2>
+      <PortalPipelineProgress :stages="data.pipeline" :is-rejected="data.application.isRejected" />
+    </div>
+
+    <!-- Two column layout for interviews + documents -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <!-- Upcoming Interviews -->
+      <div class="rounded-2xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 p-5 sm:p-6">
+        <h2 class="text-sm font-semibold text-surface-900 dark:text-surface-100 mb-4 flex items-center gap-2">
+          <Calendar class="size-4 text-brand-500" />
+          Upcoming Interviews
+        </h2>
+
+        <div v-if="data.upcomingInterviews.length > 0" class="space-y-3">
+          <PortalInterviewCard
+            v-for="iv in data.upcomingInterviews"
+            :key="iv.id"
+            :interview="iv"
+          />
+        </div>
+
+        <div v-else class="text-center py-8">
+          <Calendar class="size-8 mx-auto text-surface-300 dark:text-surface-600 mb-2" />
+          <p class="text-sm text-surface-400 dark:text-surface-500">No upcoming interviews</p>
+          <p class="text-xs text-surface-300 dark:text-surface-600 mt-1">Interviews will appear here when scheduled</p>
+        </div>
+
+        <!-- Past interviews -->
+        <div v-if="data.pastInterviews.length > 0" class="mt-6 pt-4 border-t border-surface-100 dark:border-surface-800">
+          <h3 class="text-xs font-medium text-surface-400 dark:text-surface-500 uppercase tracking-wider mb-3">Past Interviews</h3>
+          <div class="space-y-2">
+            <PortalInterviewCard
+              v-for="iv in data.pastInterviews"
+              :key="iv.id"
+              :interview="iv"
+            />
+          </div>
+        </div>
+      </div>
+
+      <!-- Documents -->
+      <div class="rounded-2xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 p-5 sm:p-6">
+        <h2 class="text-sm font-semibold text-surface-900 dark:text-surface-100 mb-4 flex items-center gap-2">
+          <FileText class="size-4 text-brand-500" />
+          Your Documents
+        </h2>
+
+        <div v-if="data.documents.length > 0" class="space-y-2">
+          <div
+            v-for="doc in data.documents"
+            :key="doc.id"
+            class="flex items-center gap-3 rounded-lg border border-surface-100 dark:border-surface-800 bg-surface-50 dark:bg-surface-800/50 px-3 py-2.5"
+          >
+            <div class="size-8 rounded-lg bg-brand-50 dark:bg-brand-900/30 flex items-center justify-center shrink-0">
+              <FileText class="size-4 text-brand-500" />
+            </div>
+            <div class="min-w-0 flex-1">
+              <p class="text-sm font-medium text-surface-700 dark:text-surface-200 truncate">
+                {{ doc.filename }}
+              </p>
+              <p class="text-xs text-surface-400 dark:text-surface-500">
+                {{ doc.type === 'resume' ? 'Resume' : doc.type === 'cover_letter' ? 'Cover Letter' : 'Document' }}
+                &middot; Uploaded {{ formatDate(doc.uploadedAt) }}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div v-else class="text-center py-8">
+          <FileText class="size-8 mx-auto text-surface-300 dark:text-surface-600 mb-2" />
+          <p class="text-sm text-surface-400 dark:text-surface-500">No documents uploaded</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Timeline -->
+    <div class="rounded-2xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 p-5 sm:p-6">
+      <h2 class="text-sm font-semibold text-surface-900 dark:text-surface-100 mb-4 flex items-center gap-2">
+        <Clock class="size-4 text-brand-500" />
+        Activity Timeline
+      </h2>
+
+      <div v-if="data.timeline.length > 0">
+        <PortalStatusTimeline :entries="data.timeline" />
+      </div>
+
+      <div v-else class="text-center py-8">
+        <Clock class="size-8 mx-auto text-surface-300 dark:text-surface-600 mb-2" />
+        <p class="text-sm text-surface-400 dark:text-surface-500">No activity yet</p>
+      </div>
+    </div>
+
+    <!-- What to expect section -->
+    <div class="rounded-2xl border border-surface-200 dark:border-surface-700 bg-gradient-to-br from-surface-50 to-brand-50/30 dark:from-surface-900 dark:to-brand-950/20 p-5 sm:p-6">
+      <h2 class="text-sm font-semibold text-surface-900 dark:text-surface-100 mb-3">What happens next?</h2>
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div class="flex items-start gap-3">
+          <div class="size-8 rounded-lg bg-brand-100 dark:bg-brand-900/40 flex items-center justify-center shrink-0 text-brand-600 dark:text-brand-400 text-sm font-bold">1</div>
+          <div>
+            <p class="text-sm font-medium text-surface-700 dark:text-surface-200">Review</p>
+            <p class="text-xs text-surface-500 dark:text-surface-400">The hiring team reviews your application</p>
+          </div>
+        </div>
+        <div class="flex items-start gap-3">
+          <div class="size-8 rounded-lg bg-brand-100 dark:bg-brand-900/40 flex items-center justify-center shrink-0 text-brand-600 dark:text-brand-400 text-sm font-bold">2</div>
+          <div>
+            <p class="text-sm font-medium text-surface-700 dark:text-surface-200">Interview</p>
+            <p class="text-xs text-surface-500 dark:text-surface-400">If selected, you'll be invited to interview</p>
+          </div>
+        </div>
+        <div class="flex items-start gap-3">
+          <div class="size-8 rounded-lg bg-brand-100 dark:bg-brand-900/40 flex items-center justify-center shrink-0 text-brand-600 dark:text-brand-400 text-sm font-bold">3</div>
+          <div>
+            <p class="text-sm font-medium text-surface-700 dark:text-surface-200">Decision</p>
+            <p class="text-xs text-surface-500 dark:text-surface-400">You'll receive a final decision via this portal</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Security info -->
+    <p class="text-center text-xs text-surface-400 dark:text-surface-500">
+      <Shield class="size-3 inline -mt-0.5" />
+      This link is private to you. Bookmark it to check back anytime.
+    </p>
+  </div>
+</template>

--- a/server/api/applications/[id].get.ts
+++ b/server/api/applications/[id].get.ts
@@ -1,10 +1,11 @@
-import { eq, and } from 'drizzle-orm'
+import { eq, and, isNull } from 'drizzle-orm'
 import { application } from '../../database/schema'
 import { applicationIdParamSchema } from '../../utils/schemas/application'
 
 /**
  * GET /api/applications/:id
  * Single application detail with related candidate, job, and question responses.
+ * Also records the first time a recruiter views the application.
  */
 export default defineEventHandler(async (event) => {
   const session = await requirePermission(event, { application: ['read'] })
@@ -46,6 +47,14 @@ export default defineEventHandler(async (event) => {
 
   if (!result) {
     throw createError({ statusCode: 404, statusMessage: 'Not found' })
+  }
+
+  // Record first view by a recruiter (fire-and-forget, non-blocking)
+  if (!result.viewedAt) {
+    db.update(application)
+      .set({ viewedAt: new Date(), viewedBy: session.user.id })
+      .where(and(eq(application.id, id), isNull(application.viewedAt)))
+      .catch(() => {})
   }
 
   return result

--- a/server/api/portal/applications/[id].get.ts
+++ b/server/api/portal/applications/[id].get.ts
@@ -1,0 +1,58 @@
+import { eq, and } from 'drizzle-orm'
+import { application } from '../../../database/schema'
+
+/**
+ * GET /api/portal/applications/:id
+ *
+ * Returns detailed dashboard data for a specific application.
+ * Requires a valid portal session cookie (Google OAuth).
+ *
+ * Security: Read-only. Session-authenticated. Only returns data
+ * for applications belonging to the authenticated email.
+ */
+export default defineEventHandler(async (event) => {
+  const sessionToken = getCookie(event, 'portal_session')
+
+  if (!sessionToken) {
+    throw createError({ statusCode: 401, statusMessage: 'Please sign in to view your applications' })
+  }
+
+  const account = await validateApplicantSession(sessionToken)
+
+  if (!account) {
+    deleteCookie(event, 'portal_session', { path: '/' })
+    throw createError({ statusCode: 401, statusMessage: 'Session expired. Please sign in again.' })
+  }
+
+  const applicationId = getRouterParam(event, 'id')
+  if (!applicationId) {
+    throw createError({ statusCode: 400, statusMessage: 'Application ID is required' })
+  }
+
+  // Find the candidate record matching this email + application
+  const app = await db.query.application.findFirst({
+    where: eq(application.id, applicationId),
+    columns: { id: true, candidateId: true, organizationId: true },
+    with: {
+      candidate: {
+        columns: { email: true },
+      },
+    },
+  })
+
+  if (!app || app.candidate.email.toLowerCase() !== account.email.toLowerCase()) {
+    throw createError({ statusCode: 404, statusMessage: 'Application not found' })
+  }
+
+  const dashboardData = await getApplicationDashboard(
+    app.id,
+    app.candidateId,
+    app.organizationId,
+  )
+
+  if (!dashboardData) {
+    throw createError({ statusCode: 404, statusMessage: 'Application not found' })
+  }
+
+  return dashboardData
+})

--- a/server/api/portal/auth/google/callback.get.ts
+++ b/server/api/portal/auth/google/callback.get.ts
@@ -1,0 +1,105 @@
+/**
+ * GET /api/portal/auth/google/callback
+ *
+ * Google OAuth callback for the applicant portal.
+ * Exchanges the authorization code for tokens, fetches the user profile,
+ * creates/updates an applicant account, and issues a portal session cookie.
+ */
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const code = typeof query.code === 'string' ? query.code : ''
+  const stateParam = typeof query.state === 'string' ? query.state : ''
+  const error = typeof query.error === 'string' ? query.error : ''
+
+  if (error) {
+    return sendRedirect(event, '/portal/auth/sign-in?error=oauth_denied')
+  }
+
+  if (!code) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing authorization code' })
+  }
+
+  // Parse state
+  let returnTo = ''
+  let portalToken = ''
+  try {
+    const state = JSON.parse(Buffer.from(stateParam, 'base64url').toString())
+    returnTo = state.returnTo || ''
+    portalToken = state.portalToken || ''
+  } catch {
+    // Ignore invalid state
+  }
+
+  const clientId = env.AUTH_GOOGLE_CLIENT_ID!
+  const clientSecret = env.AUTH_GOOGLE_CLIENT_SECRET!
+  // Must match the redirect_uri used in the init endpoint
+  const baseUrl = getRequestURL(event).origin
+  const redirectUri = `${baseUrl}/api/portal/auth/google/callback`
+
+  // Exchange code for tokens
+  const tokenResponse = await $fetch<{
+    access_token: string
+    id_token?: string
+    token_type: string
+  }>('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    body: {
+      code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: redirectUri,
+      grant_type: 'authorization_code',
+    },
+  }).catch((err) => {
+    logError('portal.google_token_exchange_failed', {
+      error_message: err instanceof Error ? err.message : String(err),
+    })
+    throw createError({ statusCode: 502, statusMessage: 'Failed to authenticate with Google' })
+  })
+
+  // Fetch user profile
+  const profile = await $fetch<{
+    sub: string
+    email: string
+    name?: string
+    picture?: string
+    email_verified?: boolean
+  }>('https://openidconnect.googleapis.com/v1/userinfo', {
+    headers: {
+      Authorization: `Bearer ${tokenResponse.access_token}`,
+    },
+  }).catch((err) => {
+    logError('portal.google_profile_fetch_failed', {
+      error_message: err instanceof Error ? err.message : String(err),
+    })
+    throw createError({ statusCode: 502, statusMessage: 'Failed to fetch Google profile' })
+  })
+
+  if (!profile.email) {
+    throw createError({ statusCode: 400, statusMessage: 'Google account does not have an email address' })
+  }
+
+  // Find or create applicant account
+  const account = await findOrCreateApplicantAccount({
+    googleId: profile.sub,
+    email: profile.email,
+    name: profile.name,
+    image: profile.picture,
+  })
+
+  // Create session
+  const sessionToken = await createApplicantSession(account.id)
+
+  // Set secure session cookie
+  setCookie(event, 'portal_session', sessionToken, {
+    httpOnly: true,
+    secure: !import.meta.dev,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 72 * 60 * 60, // 72 hours
+  })
+
+  // Redirect to portal dashboard or return URL
+  const redirectTo = returnTo || '/portal'
+  return sendRedirect(event, redirectTo)
+})

--- a/server/api/portal/auth/google/index.get.ts
+++ b/server/api/portal/auth/google/index.get.ts
@@ -1,0 +1,47 @@
+import { eq, and } from 'drizzle-orm'
+import { candidate } from '../../../../database/schema'
+
+/**
+ * GET /api/portal/auth/google
+ *
+ * Initiates Google OAuth flow for the applicant portal.
+ * Redirects the user to Google's consent screen.
+ * Reuses the same AUTH_GOOGLE credentials as the recruiter OAuth,
+ * but with a portal-specific redirect URI.
+ */
+export default defineEventHandler(async (event) => {
+  const clientId = env.AUTH_GOOGLE_CLIENT_ID
+  const clientSecret = env.AUTH_GOOGLE_CLIENT_SECRET
+
+  if (!clientId || !clientSecret) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'Google sign-in is not configured for the applicant portal',
+    })
+  }
+
+  // Read optional return URL and portal token from query
+  const query = getQuery(event)
+  const returnTo = typeof query.returnTo === 'string' ? query.returnTo : ''
+  const portalToken = typeof query.portalToken === 'string' ? query.portalToken : ''
+
+  // Build state to pass through OAuth flow
+  const state = Buffer.from(JSON.stringify({ returnTo, portalToken })).toString('base64url')
+
+  // Derive base URL from the actual request so the redirect_uri always matches
+  // the origin the browser is using (handles localhost, Railway, custom domains).
+  const baseUrl = getRequestURL(event).origin
+  const redirectUri = `${baseUrl}/api/portal/auth/google/callback`
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: 'openid email profile',
+    access_type: 'online',
+    prompt: 'select_account',
+    state,
+  })
+
+  return sendRedirect(event, `https://accounts.google.com/o/oauth2/v2/auth?${params}`)
+})

--- a/server/api/portal/auth/session.get.ts
+++ b/server/api/portal/auth/session.get.ts
@@ -1,0 +1,33 @@
+import { eq } from 'drizzle-orm'
+
+/**
+ * GET /api/portal/auth/session
+ *
+ * Returns the current applicant portal session.
+ * Used by the client to check authentication status.
+ */
+export default defineEventHandler(async (event) => {
+  const sessionToken = getCookie(event, 'portal_session')
+
+  if (!sessionToken) {
+    return { authenticated: false, account: null }
+  }
+
+  const account = await validateApplicantSession(sessionToken)
+
+  if (!account) {
+    // Clear stale cookie
+    deleteCookie(event, 'portal_session', { path: '/' })
+    return { authenticated: false, account: null }
+  }
+
+  return {
+    authenticated: true,
+    account: {
+      id: account.id,
+      email: account.email,
+      name: account.name,
+      image: account.image,
+    },
+  }
+})

--- a/server/api/portal/auth/sign-out.post.ts
+++ b/server/api/portal/auth/sign-out.post.ts
@@ -1,0 +1,21 @@
+import { eq } from 'drizzle-orm'
+import { applicantSession } from '../../../database/schema'
+
+/**
+ * POST /api/portal/auth/sign-out
+ *
+ * Signs the applicant out by deleting their session.
+ */
+export default defineEventHandler(async (event) => {
+  const sessionToken = getCookie(event, 'portal_session')
+
+  if (sessionToken) {
+    await db.delete(applicantSession)
+      .where(eq(applicantSession.token, sessionToken))
+      .catch(() => {})
+
+    deleteCookie(event, 'portal_session', { path: '/' })
+  }
+
+  return { success: true }
+})

--- a/server/api/portal/dashboard.get.ts
+++ b/server/api/portal/dashboard.get.ts
@@ -1,0 +1,34 @@
+/**
+ * GET /api/portal/dashboard
+ *
+ * Returns all applications for the authenticated applicant.
+ * Requires a valid portal session cookie (Google OAuth).
+ *
+ * Security: Read-only. Session-authenticated.
+ */
+export default defineEventHandler(async (event) => {
+  const sessionToken = getCookie(event, 'portal_session')
+
+  if (!sessionToken) {
+    throw createError({ statusCode: 401, statusMessage: 'Please sign in to view your applications' })
+  }
+
+  const account = await validateApplicantSession(sessionToken)
+
+  if (!account) {
+    deleteCookie(event, 'portal_session', { path: '/' })
+    throw createError({ statusCode: 401, statusMessage: 'Session expired. Please sign in again.' })
+  }
+
+  const applications = await getApplicantDashboardByEmail(account.email)
+
+  return {
+    account: {
+      id: account.id,
+      email: account.email,
+      name: account.name,
+      image: account.image,
+    },
+    applications,
+  }
+})

--- a/server/api/portal/token/[token].get.ts
+++ b/server/api/portal/token/[token].get.ts
@@ -1,0 +1,50 @@
+import { eq, and } from 'drizzle-orm'
+import { application, job, candidate, interview, organization, applicantPortalToken } from '../../../database/schema'
+
+/** Rate limit: max 30 requests per IP per minute */
+const portalTokenRateLimit = createRateLimiter({
+  windowMs: 60 * 1000,
+  maxRequests: 30,
+  message: 'Too many requests. Please try again shortly.',
+})
+
+/**
+ * GET /api/portal/token/:token
+ *
+ * Validates a portal access token and returns full application dashboard data.
+ * This is the primary endpoint for token-based (no-login) portal access.
+ *
+ * Returns: job details, application status, timeline, upcoming interviews,
+ * organization name, and document list.
+ *
+ * Security: Read-only. Token is validated and rate-limited.
+ */
+export default defineEventHandler(async (event) => {
+  if (process.env.NODE_ENV === 'production' && !process.env.CI) {
+    await portalTokenRateLimit(event)
+  }
+
+  const token = getRouterParam(event, 'token')
+
+  if (!token || token.length !== 64 || !/^[0-9a-f]+$/.test(token)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid token format' })
+  }
+
+  const tokenData = await validatePortalToken(token)
+
+  if (!tokenData) {
+    throw createError({ statusCode: 404, statusMessage: 'Invalid or expired access link' })
+  }
+
+  const dashboardData = await getApplicationDashboard(
+    tokenData.applicationId,
+    tokenData.candidateId,
+    tokenData.organizationId,
+  )
+
+  if (!dashboardData) {
+    throw createError({ statusCode: 404, statusMessage: 'Application not found' })
+  }
+
+  return dashboardData
+})

--- a/server/api/public/jobs/[slug]/apply.post.ts
+++ b/server/api/public/jobs/[slug]/apply.post.ts
@@ -648,8 +648,30 @@ export default defineEventHandler(async (event) => {
     is_returning_candidate: !!existingCandidate,
   })
 
+  // ─────────────────────────────────────────────
+  // 13. Generate portal access token for applicant dashboard
+  // ─────────────────────────────────────────────
+
+  let portalAccessToken: string | null = null
+  try {
+    portalAccessToken = await createPortalToken(
+      newApplication!.id,
+      candidateId,
+      orgId,
+    )
+  } catch (portalErr) {
+    // Portal token is best-effort — never fail an application for it
+    logWarn('application.portal_token_failed', {
+      application_id: newApplication?.id,
+      error_message: portalErr instanceof Error ? portalErr.message : String(portalErr),
+    })
+  }
+
   setResponseStatus(event, 201)
-  return { success: true }
+  return {
+    success: true,
+    portalToken: portalAccessToken,
+  }
 })
 
 // ─────────────────────────────────────────────

--- a/server/database/migrations/0021_blushing_thing.sql
+++ b/server/database/migrations/0021_blushing_thing.sql
@@ -1,0 +1,44 @@
+CREATE TABLE "applicant_account" (
+	"id" text PRIMARY KEY NOT NULL,
+	"google_id" text NOT NULL,
+	"email" text NOT NULL,
+	"name" text,
+	"image" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "applicant_account_google_id_unique" UNIQUE("google_id")
+);
+--> statement-breakpoint
+CREATE TABLE "applicant_portal_token" (
+	"id" text PRIMARY KEY NOT NULL,
+	"token" text NOT NULL,
+	"application_id" text NOT NULL,
+	"candidate_id" text NOT NULL,
+	"organization_id" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"last_accessed_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "applicant_portal_token_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE TABLE "applicant_session" (
+	"id" text PRIMARY KEY NOT NULL,
+	"applicant_account_id" text NOT NULL,
+	"token" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "applicant_session_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+ALTER TABLE "applicant_portal_token" ADD CONSTRAINT "applicant_portal_token_application_id_application_id_fk" FOREIGN KEY ("application_id") REFERENCES "public"."application"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "applicant_portal_token" ADD CONSTRAINT "applicant_portal_token_candidate_id_candidate_id_fk" FOREIGN KEY ("candidate_id") REFERENCES "public"."candidate"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "applicant_portal_token" ADD CONSTRAINT "applicant_portal_token_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "applicant_session" ADD CONSTRAINT "applicant_session_applicant_account_id_applicant_account_id_fk" FOREIGN KEY ("applicant_account_id") REFERENCES "public"."applicant_account"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "applicant_account_email_idx" ON "applicant_account" USING btree ("email");--> statement-breakpoint
+CREATE UNIQUE INDEX "applicant_account_google_id_idx" ON "applicant_account" USING btree ("google_id");--> statement-breakpoint
+CREATE INDEX "portal_token_application_id_idx" ON "applicant_portal_token" USING btree ("application_id");--> statement-breakpoint
+CREATE INDEX "portal_token_candidate_id_idx" ON "applicant_portal_token" USING btree ("candidate_id");--> statement-breakpoint
+CREATE INDEX "portal_token_organization_id_idx" ON "applicant_portal_token" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "portal_token_token_idx" ON "applicant_portal_token" USING btree ("token");--> statement-breakpoint
+CREATE INDEX "applicant_session_account_id_idx" ON "applicant_session" USING btree ("applicant_account_id");--> statement-breakpoint
+CREATE INDEX "applicant_session_token_idx" ON "applicant_session" USING btree ("token");

--- a/server/database/migrations/0022_mute_green_goblin.sql
+++ b/server/database/migrations/0022_mute_green_goblin.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "application" ADD COLUMN "viewed_at" timestamp;--> statement-breakpoint
+ALTER TABLE "application" ADD COLUMN "viewed_by" text;--> statement-breakpoint
+ALTER TABLE "application" ADD CONSTRAINT "application_viewed_by_user_id_fk" FOREIGN KEY ("viewed_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;

--- a/server/database/migrations/meta/0021_snapshot.json
+++ b/server/database/migrations/meta/0021_snapshot.json
@@ -1,0 +1,4505 @@
+{
+  "id": "c3684bb5-9152-4a7d-bb6a-26979662e546",
+  "prevId": "6383b697-d628-4372-b8cc-54e02b88b5bd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_org_unique_idx": {
+          "name": "member_user_org_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit": {
+      "name": "rate_limit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_key_idx": {
+          "name": "rate_limit_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "activity_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_log_organization_id_idx": {
+          "name": "activity_log_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_log_actor_id_idx": {
+          "name": "activity_log_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_log_resource_idx": {
+          "name": "activity_log_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_log_created_at_idx": {
+          "name": "activity_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_organization_id_organization_id_fk": {
+          "name": "activity_log_organization_id_organization_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_log_actor_id_user_id_fk": {
+          "name": "activity_log_actor_id_user_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_config": {
+      "name": "ai_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gpt-4o-mini'"
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4096
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_config_organization_id_idx": {
+          "name": "ai_config_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_config_organization_id_organization_id_fk": {
+          "name": "ai_config_organization_id_organization_id_fk",
+          "tableFrom": "ai_config",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_run": {
+      "name": "analysis_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "analysis_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_snapshot": {
+          "name": "criteria_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composite_score": {
+          "name": "composite_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scored_by_id": {
+          "name": "scored_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analysis_run_organization_id_idx": {
+          "name": "analysis_run_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analysis_run_application_id_idx": {
+          "name": "analysis_run_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analysis_run_created_at_idx": {
+          "name": "analysis_run_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_run_organization_id_organization_id_fk": {
+          "name": "analysis_run_organization_id_organization_id_fk",
+          "tableFrom": "analysis_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "analysis_run_application_id_application_id_fk": {
+          "name": "analysis_run_application_id_application_id_fk",
+          "tableFrom": "analysis_run",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "analysis_run_scored_by_id_user_id_fk": {
+          "name": "analysis_run_scored_by_id_user_id_fk",
+          "tableFrom": "analysis_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "scored_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application": {
+      "name": "application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_letter_text": {
+          "name": "cover_letter_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_organization_id_idx": {
+          "name": "application_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_candidate_id_idx": {
+          "name": "application_candidate_id_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_job_id_idx": {
+          "name": "application_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_org_candidate_job_idx": {
+          "name": "application_org_candidate_job_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_organization_id_organization_id_fk": {
+          "name": "application_organization_id_organization_id_fk",
+          "tableFrom": "application",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_candidate_id_candidate_id_fk": {
+          "name": "application_candidate_id_candidate_id_fk",
+          "tableFrom": "application",
+          "tableTo": "candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_job_id_job_id_fk": {
+          "name": "application_job_id_job_id_fk",
+          "tableFrom": "application",
+          "tableTo": "job",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_source": {
+      "name": "application_source",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "source_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "tracking_link_id": {
+          "name": "tracking_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_source": {
+          "name": "utm_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_medium": {
+          "name": "utm_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_campaign": {
+          "name": "utm_campaign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_term": {
+          "name": "utm_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_content": {
+          "name": "utm_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer_domain": {
+          "name": "referrer_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_source_organization_id_idx": {
+          "name": "application_source_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_source_application_id_idx": {
+          "name": "application_source_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_source_channel_idx": {
+          "name": "application_source_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_source_tracking_link_id_idx": {
+          "name": "application_source_tracking_link_id_idx",
+          "columns": [
+            {
+              "expression": "tracking_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_source_application_idx": {
+          "name": "application_source_application_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_source_organization_id_organization_id_fk": {
+          "name": "application_source_organization_id_organization_id_fk",
+          "tableFrom": "application_source",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_source_application_id_application_id_fk": {
+          "name": "application_source_application_id_application_id_fk",
+          "tableFrom": "application_source",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_source_tracking_link_id_tracking_link_id_fk": {
+          "name": "application_source_tracking_link_id_tracking_link_id_fk",
+          "tableFrom": "application_source",
+          "tableTo": "tracking_link",
+          "columnsFrom": [
+            "tracking_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_integration": {
+      "name": "calendar_integration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "calendar_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google'"
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_channel_id": {
+          "name": "webhook_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_resource_id": {
+          "name": "webhook_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_expiration": {
+          "name": "webhook_expiration",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_token": {
+          "name": "sync_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_integration_user_provider_idx": {
+          "name": "calendar_integration_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_integration_webhook_channel_idx": {
+          "name": "calendar_integration_webhook_channel_idx",
+          "columns": [
+            {
+              "expression": "webhook_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_integration_user_id_user_id_fk": {
+          "name": "calendar_integration_user_id_user_id_fk",
+          "tableFrom": "calendar_integration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate": {
+      "name": "candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_organization_id_idx": {
+          "name": "candidate_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_org_email_idx": {
+          "name": "candidate_org_email_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "candidate_organization_id_organization_id_fk": {
+          "name": "candidate_organization_id_organization_id_fk",
+          "tableFrom": "candidate",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment": {
+      "name": "comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "comment_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comment_organization_id_idx": {
+          "name": "comment_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comment_target_idx": {
+          "name": "comment_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comment_author_id_idx": {
+          "name": "comment_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_organization_id_organization_id_fk": {
+          "name": "comment_organization_id_organization_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_author_id_user_id_fk": {
+          "name": "comment_author_id_user_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.criterion_score": {
+      "name": "criterion_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criterion_key": {
+          "name": "criterion_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_score": {
+          "name": "applicant_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaps": {
+          "name": "gaps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "criterion_score_organization_id_idx": {
+          "name": "criterion_score_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "criterion_score_application_id_idx": {
+          "name": "criterion_score_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "criterion_score_app_criterion_idx": {
+          "name": "criterion_score_app_criterion_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "criterion_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "criterion_score_organization_id_organization_id_fk": {
+          "name": "criterion_score_organization_id_organization_id_fk",
+          "tableFrom": "criterion_score",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "criterion_score_application_id_application_id_fk": {
+          "name": "criterion_score_application_id_application_id_fk",
+          "tableFrom": "criterion_score",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document": {
+      "name": "document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resume'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_content": {
+          "name": "parsed_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_organization_id_idx": {
+          "name": "document_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_candidate_id_idx": {
+          "name": "document_candidate_id_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_organization_id_organization_id_fk": {
+          "name": "document_organization_id_organization_id_fk",
+          "tableFrom": "document",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_candidate_id_candidate_id_fk": {
+          "name": "document_candidate_id_candidate_id_fk",
+          "tableFrom": "document",
+          "tableTo": "candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "document_storage_key_unique": {
+          "name": "document_storage_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_template": {
+      "name": "email_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_template_organization_id_idx": {
+          "name": "email_template_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_template_created_by_id_idx": {
+          "name": "email_template_created_by_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_template_organization_id_organization_id_fk": {
+          "name": "email_template_organization_id_organization_id_fk",
+          "tableFrom": "email_template",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_template_created_by_id_user_id_fk": {
+          "name": "email_template_created_by_id_user_id_fk",
+          "tableFrom": "email_template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview": {
+      "name": "interview",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'video'"
+        },
+        "status": {
+          "name": "status",
+          "type": "interview_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interviewers": {
+          "name": "interviewers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitation_sent_at": {
+          "name": "invitation_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_response": {
+          "name": "candidate_response",
+          "type": "candidate_response",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "candidate_responded_at": {
+          "name": "candidate_responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_calendar_event_id": {
+          "name": "google_calendar_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_calendar_event_link": {
+          "name": "google_calendar_event_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "interview_organization_id_idx": {
+          "name": "interview_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interview_application_id_idx": {
+          "name": "interview_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interview_scheduled_at_idx": {
+          "name": "interview_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interview_status_idx": {
+          "name": "interview_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interview_created_by_id_idx": {
+          "name": "interview_created_by_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interview_organization_id_organization_id_fk": {
+          "name": "interview_organization_id_organization_id_fk",
+          "tableFrom": "interview",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interview_application_id_application_id_fk": {
+          "name": "interview_application_id_application_id_fk",
+          "tableFrom": "interview",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interview_created_by_id_user_id_fk": {
+          "name": "interview_created_by_id_user_id_fk",
+          "tableFrom": "interview",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invite_link_organization_id_idx": {
+          "name": "invite_link_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_link_token_idx": {
+          "name": "invite_link_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_organization_id_organization_id_fk": {
+          "name": "invite_link_organization_id_organization_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_link_created_by_id_user_id_fk": {
+          "name": "invite_link_created_by_id_user_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_token_unique": {
+          "name": "invite_link_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job": {
+      "name": "job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "job_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_time'"
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "salary_min": {
+          "name": "salary_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary_max": {
+          "name": "salary_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary_currency": {
+          "name": "salary_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary_unit": {
+          "name": "salary_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_status": {
+          "name": "remote_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_through": {
+          "name": "valid_through",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_resume": {
+          "name": "require_resume",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "require_cover_letter": {
+          "name": "require_cover_letter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_score_on_apply": {
+          "name": "auto_score_on_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_organization_id_idx": {
+          "name": "job_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_organization_id_organization_id_fk": {
+          "name": "job_organization_id_organization_id_fk",
+          "tableFrom": "job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_slug_unique": {
+          "name": "job_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_question": {
+      "name": "job_question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'short_text'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_question_organization_id_idx": {
+          "name": "job_question_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_question_job_id_idx": {
+          "name": "job_question_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_question_organization_id_organization_id_fk": {
+          "name": "job_question_organization_id_organization_id_fk",
+          "tableFrom": "job_question",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "job_question_job_id_job_id_fk": {
+          "name": "job_question_job_id_job_id_fk",
+          "tableFrom": "job_question",
+          "tableTo": "job",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.join_request": {
+      "name": "join_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "join_request_organization_id_idx": {
+          "name": "join_request_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "join_request_user_id_idx": {
+          "name": "join_request_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "join_request_status_idx": {
+          "name": "join_request_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "join_request_user_id_user_id_fk": {
+          "name": "join_request_user_id_user_id_fk",
+          "tableFrom": "join_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "join_request_organization_id_organization_id_fk": {
+          "name": "join_request_organization_id_organization_id_fk",
+          "tableFrom": "join_request",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "join_request_reviewed_by_id_user_id_fk": {
+          "name": "join_request_reviewed_by_id_user_id_fk",
+          "tableFrom": "join_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_response": {
+      "name": "question_response",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_response_organization_id_idx": {
+          "name": "question_response_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_response_application_id_idx": {
+          "name": "question_response_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_response_question_id_idx": {
+          "name": "question_response_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_response_organization_id_organization_id_fk": {
+          "name": "question_response_organization_id_organization_id_fk",
+          "tableFrom": "question_response",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_response_application_id_application_id_fk": {
+          "name": "question_response_application_id_application_id_fk",
+          "tableFrom": "question_response",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_response_question_id_job_question_id_fk": {
+          "name": "question_response_question_id_job_question_id_fk",
+          "tableFrom": "question_response",
+          "tableTo": "job_question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scoring_criterion": {
+      "name": "scoring_criterion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "criterion_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scoring_criterion_organization_id_idx": {
+          "name": "scoring_criterion_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scoring_criterion_job_id_idx": {
+          "name": "scoring_criterion_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scoring_criterion_job_key_idx": {
+          "name": "scoring_criterion_job_key_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scoring_criterion_organization_id_organization_id_fk": {
+          "name": "scoring_criterion_organization_id_organization_id_fk",
+          "tableFrom": "scoring_criterion",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scoring_criterion_job_id_job_id_fk": {
+          "name": "scoring_criterion_job_id_job_id_fk",
+          "tableFrom": "scoring_criterion",
+          "tableTo": "job",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracking_link": {
+      "name": "tracking_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "source_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utm_source": {
+          "name": "utm_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_medium": {
+          "name": "utm_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_campaign": {
+          "name": "utm_campaign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_term": {
+          "name": "utm_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_content": {
+          "name": "utm_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "click_count": {
+          "name": "click_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "application_count": {
+          "name": "application_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracking_link_organization_id_idx": {
+          "name": "tracking_link_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracking_link_job_id_idx": {
+          "name": "tracking_link_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracking_link_code_idx": {
+          "name": "tracking_link_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracking_link_channel_idx": {
+          "name": "tracking_link_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tracking_link_organization_id_organization_id_fk": {
+          "name": "tracking_link_organization_id_organization_id_fk",
+          "tableFrom": "tracking_link",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tracking_link_job_id_job_id_fk": {
+          "name": "tracking_link_job_id_job_id_fk",
+          "tableFrom": "tracking_link",
+          "tableTo": "job",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tracking_link_created_by_id_user_id_fk": {
+          "name": "tracking_link_created_by_id_user_id_fk",
+          "tableFrom": "tracking_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tracking_link_code_unique": {
+          "name": "tracking_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sso_provider_domain_idx": {
+          "name": "sso_provider_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_provider_id_idx": {
+          "name": "sso_provider_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applicant_account": {
+      "name": "applicant_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "applicant_account_email_idx": {
+          "name": "applicant_account_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applicant_account_google_id_idx": {
+          "name": "applicant_account_google_id_idx",
+          "columns": [
+            {
+              "expression": "google_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "applicant_account_google_id_unique": {
+          "name": "applicant_account_google_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applicant_portal_token": {
+      "name": "applicant_portal_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "portal_token_application_id_idx": {
+          "name": "portal_token_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "portal_token_candidate_id_idx": {
+          "name": "portal_token_candidate_id_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "portal_token_organization_id_idx": {
+          "name": "portal_token_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "portal_token_token_idx": {
+          "name": "portal_token_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applicant_portal_token_application_id_application_id_fk": {
+          "name": "applicant_portal_token_application_id_application_id_fk",
+          "tableFrom": "applicant_portal_token",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applicant_portal_token_candidate_id_candidate_id_fk": {
+          "name": "applicant_portal_token_candidate_id_candidate_id_fk",
+          "tableFrom": "applicant_portal_token",
+          "tableTo": "candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applicant_portal_token_organization_id_organization_id_fk": {
+          "name": "applicant_portal_token_organization_id_organization_id_fk",
+          "tableFrom": "applicant_portal_token",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "applicant_portal_token_token_unique": {
+          "name": "applicant_portal_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applicant_session": {
+      "name": "applicant_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applicant_account_id": {
+          "name": "applicant_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "applicant_session_account_id_idx": {
+          "name": "applicant_session_account_id_idx",
+          "columns": [
+            {
+              "expression": "applicant_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applicant_session_token_idx": {
+          "name": "applicant_session_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applicant_session_applicant_account_id_applicant_account_id_fk": {
+          "name": "applicant_session_applicant_account_id_applicant_account_id_fk",
+          "tableFrom": "applicant_session",
+          "tableTo": "applicant_account",
+          "columnsFrom": [
+            "applicant_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "applicant_session_token_unique": {
+          "name": "applicant_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.activity_action": {
+      "name": "activity_action",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated",
+        "deleted",
+        "status_changed",
+        "comment_added",
+        "member_invited",
+        "member_removed",
+        "member_role_changed",
+        "scored"
+      ]
+    },
+    "public.analysis_run_status": {
+      "name": "analysis_run_status",
+      "schema": "public",
+      "values": [
+        "completed",
+        "failed",
+        "partial"
+      ]
+    },
+    "public.application_status": {
+      "name": "application_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "screening",
+        "interview",
+        "offer",
+        "hired",
+        "rejected"
+      ]
+    },
+    "public.calendar_provider": {
+      "name": "calendar_provider",
+      "schema": "public",
+      "values": [
+        "google"
+      ]
+    },
+    "public.candidate_response": {
+      "name": "candidate_response",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "tentative"
+      ]
+    },
+    "public.comment_target": {
+      "name": "comment_target",
+      "schema": "public",
+      "values": [
+        "candidate",
+        "application",
+        "job"
+      ]
+    },
+    "public.criterion_category": {
+      "name": "criterion_category",
+      "schema": "public",
+      "values": [
+        "technical",
+        "experience",
+        "soft_skills",
+        "education",
+        "culture",
+        "custom"
+      ]
+    },
+    "public.document_type": {
+      "name": "document_type",
+      "schema": "public",
+      "values": [
+        "resume",
+        "cover_letter",
+        "other"
+      ]
+    },
+    "public.interview_status": {
+      "name": "interview_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "cancelled",
+        "no_show"
+      ]
+    },
+    "public.interview_type": {
+      "name": "interview_type",
+      "schema": "public",
+      "values": [
+        "phone",
+        "video",
+        "in_person",
+        "panel",
+        "technical",
+        "take_home"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "open",
+        "closed",
+        "archived"
+      ]
+    },
+    "public.job_type": {
+      "name": "job_type",
+      "schema": "public",
+      "values": [
+        "full_time",
+        "part_time",
+        "contract",
+        "internship"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.question_type": {
+      "name": "question_type",
+      "schema": "public",
+      "values": [
+        "short_text",
+        "long_text",
+        "single_select",
+        "multi_select",
+        "number",
+        "date",
+        "url",
+        "checkbox",
+        "file_upload"
+      ]
+    },
+    "public.source_channel": {
+      "name": "source_channel",
+      "schema": "public",
+      "values": [
+        "linkedin",
+        "indeed",
+        "glassdoor",
+        "ziprecruiter",
+        "monster",
+        "handshake",
+        "angellist",
+        "wellfound",
+        "dice",
+        "stackoverflow",
+        "weworkremotely",
+        "remoteok",
+        "builtin",
+        "hired",
+        "lever",
+        "greenhouse_board",
+        "google_jobs",
+        "facebook",
+        "twitter",
+        "instagram",
+        "tiktok",
+        "reddit",
+        "referral",
+        "career_site",
+        "email",
+        "event",
+        "agency",
+        "direct",
+        "other",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/database/migrations/meta/0022_snapshot.json
+++ b/server/database/migrations/meta/0022_snapshot.json
@@ -1,0 +1,4530 @@
+{
+  "id": "37783ea2-ce5b-4afa-859d-82e5a915188d",
+  "prevId": "c3684bb5-9152-4a7d-bb6a-26979662e546",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_org_unique_idx": {
+          "name": "member_user_org_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit": {
+      "name": "rate_limit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_key_idx": {
+          "name": "rate_limit_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "activity_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_log_organization_id_idx": {
+          "name": "activity_log_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_log_actor_id_idx": {
+          "name": "activity_log_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_log_resource_idx": {
+          "name": "activity_log_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_log_created_at_idx": {
+          "name": "activity_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_organization_id_organization_id_fk": {
+          "name": "activity_log_organization_id_organization_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_log_actor_id_user_id_fk": {
+          "name": "activity_log_actor_id_user_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_config": {
+      "name": "ai_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gpt-4o-mini'"
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4096
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_config_organization_id_idx": {
+          "name": "ai_config_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_config_organization_id_organization_id_fk": {
+          "name": "ai_config_organization_id_organization_id_fk",
+          "tableFrom": "ai_config",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_run": {
+      "name": "analysis_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "analysis_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_snapshot": {
+          "name": "criteria_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composite_score": {
+          "name": "composite_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scored_by_id": {
+          "name": "scored_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analysis_run_organization_id_idx": {
+          "name": "analysis_run_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analysis_run_application_id_idx": {
+          "name": "analysis_run_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analysis_run_created_at_idx": {
+          "name": "analysis_run_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_run_organization_id_organization_id_fk": {
+          "name": "analysis_run_organization_id_organization_id_fk",
+          "tableFrom": "analysis_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "analysis_run_application_id_application_id_fk": {
+          "name": "analysis_run_application_id_application_id_fk",
+          "tableFrom": "analysis_run",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "analysis_run_scored_by_id_user_id_fk": {
+          "name": "analysis_run_scored_by_id_user_id_fk",
+          "tableFrom": "analysis_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "scored_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application": {
+      "name": "application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_letter_text": {
+          "name": "cover_letter_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewed_by": {
+          "name": "viewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_organization_id_idx": {
+          "name": "application_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_candidate_id_idx": {
+          "name": "application_candidate_id_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_job_id_idx": {
+          "name": "application_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_org_candidate_job_idx": {
+          "name": "application_org_candidate_job_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_organization_id_organization_id_fk": {
+          "name": "application_organization_id_organization_id_fk",
+          "tableFrom": "application",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_candidate_id_candidate_id_fk": {
+          "name": "application_candidate_id_candidate_id_fk",
+          "tableFrom": "application",
+          "tableTo": "candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_job_id_job_id_fk": {
+          "name": "application_job_id_job_id_fk",
+          "tableFrom": "application",
+          "tableTo": "job",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_viewed_by_user_id_fk": {
+          "name": "application_viewed_by_user_id_fk",
+          "tableFrom": "application",
+          "tableTo": "user",
+          "columnsFrom": [
+            "viewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_source": {
+      "name": "application_source",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "source_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "tracking_link_id": {
+          "name": "tracking_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_source": {
+          "name": "utm_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_medium": {
+          "name": "utm_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_campaign": {
+          "name": "utm_campaign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_term": {
+          "name": "utm_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_content": {
+          "name": "utm_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer_domain": {
+          "name": "referrer_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_source_organization_id_idx": {
+          "name": "application_source_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_source_application_id_idx": {
+          "name": "application_source_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_source_channel_idx": {
+          "name": "application_source_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_source_tracking_link_id_idx": {
+          "name": "application_source_tracking_link_id_idx",
+          "columns": [
+            {
+              "expression": "tracking_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_source_application_idx": {
+          "name": "application_source_application_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_source_organization_id_organization_id_fk": {
+          "name": "application_source_organization_id_organization_id_fk",
+          "tableFrom": "application_source",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_source_application_id_application_id_fk": {
+          "name": "application_source_application_id_application_id_fk",
+          "tableFrom": "application_source",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_source_tracking_link_id_tracking_link_id_fk": {
+          "name": "application_source_tracking_link_id_tracking_link_id_fk",
+          "tableFrom": "application_source",
+          "tableTo": "tracking_link",
+          "columnsFrom": [
+            "tracking_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_integration": {
+      "name": "calendar_integration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "calendar_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google'"
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_channel_id": {
+          "name": "webhook_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_resource_id": {
+          "name": "webhook_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_expiration": {
+          "name": "webhook_expiration",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_token": {
+          "name": "sync_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_integration_user_provider_idx": {
+          "name": "calendar_integration_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_integration_webhook_channel_idx": {
+          "name": "calendar_integration_webhook_channel_idx",
+          "columns": [
+            {
+              "expression": "webhook_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_integration_user_id_user_id_fk": {
+          "name": "calendar_integration_user_id_user_id_fk",
+          "tableFrom": "calendar_integration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate": {
+      "name": "candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_organization_id_idx": {
+          "name": "candidate_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_org_email_idx": {
+          "name": "candidate_org_email_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "candidate_organization_id_organization_id_fk": {
+          "name": "candidate_organization_id_organization_id_fk",
+          "tableFrom": "candidate",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment": {
+      "name": "comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "comment_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comment_organization_id_idx": {
+          "name": "comment_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comment_target_idx": {
+          "name": "comment_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comment_author_id_idx": {
+          "name": "comment_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_organization_id_organization_id_fk": {
+          "name": "comment_organization_id_organization_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_author_id_user_id_fk": {
+          "name": "comment_author_id_user_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.criterion_score": {
+      "name": "criterion_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criterion_key": {
+          "name": "criterion_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_score": {
+          "name": "applicant_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaps": {
+          "name": "gaps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "criterion_score_organization_id_idx": {
+          "name": "criterion_score_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "criterion_score_application_id_idx": {
+          "name": "criterion_score_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "criterion_score_app_criterion_idx": {
+          "name": "criterion_score_app_criterion_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "criterion_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "criterion_score_organization_id_organization_id_fk": {
+          "name": "criterion_score_organization_id_organization_id_fk",
+          "tableFrom": "criterion_score",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "criterion_score_application_id_application_id_fk": {
+          "name": "criterion_score_application_id_application_id_fk",
+          "tableFrom": "criterion_score",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document": {
+      "name": "document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resume'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_content": {
+          "name": "parsed_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_organization_id_idx": {
+          "name": "document_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_candidate_id_idx": {
+          "name": "document_candidate_id_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_organization_id_organization_id_fk": {
+          "name": "document_organization_id_organization_id_fk",
+          "tableFrom": "document",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_candidate_id_candidate_id_fk": {
+          "name": "document_candidate_id_candidate_id_fk",
+          "tableFrom": "document",
+          "tableTo": "candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "document_storage_key_unique": {
+          "name": "document_storage_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_template": {
+      "name": "email_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_template_organization_id_idx": {
+          "name": "email_template_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_template_created_by_id_idx": {
+          "name": "email_template_created_by_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_template_organization_id_organization_id_fk": {
+          "name": "email_template_organization_id_organization_id_fk",
+          "tableFrom": "email_template",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_template_created_by_id_user_id_fk": {
+          "name": "email_template_created_by_id_user_id_fk",
+          "tableFrom": "email_template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview": {
+      "name": "interview",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'video'"
+        },
+        "status": {
+          "name": "status",
+          "type": "interview_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interviewers": {
+          "name": "interviewers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitation_sent_at": {
+          "name": "invitation_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_response": {
+          "name": "candidate_response",
+          "type": "candidate_response",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "candidate_responded_at": {
+          "name": "candidate_responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_calendar_event_id": {
+          "name": "google_calendar_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_calendar_event_link": {
+          "name": "google_calendar_event_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "interview_organization_id_idx": {
+          "name": "interview_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interview_application_id_idx": {
+          "name": "interview_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interview_scheduled_at_idx": {
+          "name": "interview_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interview_status_idx": {
+          "name": "interview_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interview_created_by_id_idx": {
+          "name": "interview_created_by_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interview_organization_id_organization_id_fk": {
+          "name": "interview_organization_id_organization_id_fk",
+          "tableFrom": "interview",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interview_application_id_application_id_fk": {
+          "name": "interview_application_id_application_id_fk",
+          "tableFrom": "interview",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interview_created_by_id_user_id_fk": {
+          "name": "interview_created_by_id_user_id_fk",
+          "tableFrom": "interview",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_link": {
+      "name": "invite_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invite_link_organization_id_idx": {
+          "name": "invite_link_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_link_token_idx": {
+          "name": "invite_link_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_link_organization_id_organization_id_fk": {
+          "name": "invite_link_organization_id_organization_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_link_created_by_id_user_id_fk": {
+          "name": "invite_link_created_by_id_user_id_fk",
+          "tableFrom": "invite_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_link_token_unique": {
+          "name": "invite_link_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job": {
+      "name": "job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "job_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_time'"
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "salary_min": {
+          "name": "salary_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary_max": {
+          "name": "salary_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary_currency": {
+          "name": "salary_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary_unit": {
+          "name": "salary_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_status": {
+          "name": "remote_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_through": {
+          "name": "valid_through",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_resume": {
+          "name": "require_resume",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "require_cover_letter": {
+          "name": "require_cover_letter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_score_on_apply": {
+          "name": "auto_score_on_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_organization_id_idx": {
+          "name": "job_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_organization_id_organization_id_fk": {
+          "name": "job_organization_id_organization_id_fk",
+          "tableFrom": "job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_slug_unique": {
+          "name": "job_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_question": {
+      "name": "job_question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'short_text'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_question_organization_id_idx": {
+          "name": "job_question_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_question_job_id_idx": {
+          "name": "job_question_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_question_organization_id_organization_id_fk": {
+          "name": "job_question_organization_id_organization_id_fk",
+          "tableFrom": "job_question",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "job_question_job_id_job_id_fk": {
+          "name": "job_question_job_id_job_id_fk",
+          "tableFrom": "job_question",
+          "tableTo": "job",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.join_request": {
+      "name": "join_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "join_request_organization_id_idx": {
+          "name": "join_request_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "join_request_user_id_idx": {
+          "name": "join_request_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "join_request_status_idx": {
+          "name": "join_request_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "join_request_user_id_user_id_fk": {
+          "name": "join_request_user_id_user_id_fk",
+          "tableFrom": "join_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "join_request_organization_id_organization_id_fk": {
+          "name": "join_request_organization_id_organization_id_fk",
+          "tableFrom": "join_request",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "join_request_reviewed_by_id_user_id_fk": {
+          "name": "join_request_reviewed_by_id_user_id_fk",
+          "tableFrom": "join_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_response": {
+      "name": "question_response",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_response_organization_id_idx": {
+          "name": "question_response_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_response_application_id_idx": {
+          "name": "question_response_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_response_question_id_idx": {
+          "name": "question_response_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_response_organization_id_organization_id_fk": {
+          "name": "question_response_organization_id_organization_id_fk",
+          "tableFrom": "question_response",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_response_application_id_application_id_fk": {
+          "name": "question_response_application_id_application_id_fk",
+          "tableFrom": "question_response",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_response_question_id_job_question_id_fk": {
+          "name": "question_response_question_id_job_question_id_fk",
+          "tableFrom": "question_response",
+          "tableTo": "job_question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scoring_criterion": {
+      "name": "scoring_criterion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "criterion_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scoring_criterion_organization_id_idx": {
+          "name": "scoring_criterion_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scoring_criterion_job_id_idx": {
+          "name": "scoring_criterion_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scoring_criterion_job_key_idx": {
+          "name": "scoring_criterion_job_key_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scoring_criterion_organization_id_organization_id_fk": {
+          "name": "scoring_criterion_organization_id_organization_id_fk",
+          "tableFrom": "scoring_criterion",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scoring_criterion_job_id_job_id_fk": {
+          "name": "scoring_criterion_job_id_job_id_fk",
+          "tableFrom": "scoring_criterion",
+          "tableTo": "job",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracking_link": {
+      "name": "tracking_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "source_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utm_source": {
+          "name": "utm_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_medium": {
+          "name": "utm_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_campaign": {
+          "name": "utm_campaign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_term": {
+          "name": "utm_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_content": {
+          "name": "utm_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "click_count": {
+          "name": "click_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "application_count": {
+          "name": "application_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracking_link_organization_id_idx": {
+          "name": "tracking_link_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracking_link_job_id_idx": {
+          "name": "tracking_link_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracking_link_code_idx": {
+          "name": "tracking_link_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracking_link_channel_idx": {
+          "name": "tracking_link_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tracking_link_organization_id_organization_id_fk": {
+          "name": "tracking_link_organization_id_organization_id_fk",
+          "tableFrom": "tracking_link",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tracking_link_job_id_job_id_fk": {
+          "name": "tracking_link_job_id_job_id_fk",
+          "tableFrom": "tracking_link",
+          "tableTo": "job",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tracking_link_created_by_id_user_id_fk": {
+          "name": "tracking_link_created_by_id_user_id_fk",
+          "tableFrom": "tracking_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tracking_link_code_unique": {
+          "name": "tracking_link_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sso_provider_domain_idx": {
+          "name": "sso_provider_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_provider_id_idx": {
+          "name": "sso_provider_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applicant_account": {
+      "name": "applicant_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "applicant_account_email_idx": {
+          "name": "applicant_account_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applicant_account_google_id_idx": {
+          "name": "applicant_account_google_id_idx",
+          "columns": [
+            {
+              "expression": "google_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "applicant_account_google_id_unique": {
+          "name": "applicant_account_google_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applicant_portal_token": {
+      "name": "applicant_portal_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "portal_token_application_id_idx": {
+          "name": "portal_token_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "portal_token_candidate_id_idx": {
+          "name": "portal_token_candidate_id_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "portal_token_organization_id_idx": {
+          "name": "portal_token_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "portal_token_token_idx": {
+          "name": "portal_token_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applicant_portal_token_application_id_application_id_fk": {
+          "name": "applicant_portal_token_application_id_application_id_fk",
+          "tableFrom": "applicant_portal_token",
+          "tableTo": "application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applicant_portal_token_candidate_id_candidate_id_fk": {
+          "name": "applicant_portal_token_candidate_id_candidate_id_fk",
+          "tableFrom": "applicant_portal_token",
+          "tableTo": "candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applicant_portal_token_organization_id_organization_id_fk": {
+          "name": "applicant_portal_token_organization_id_organization_id_fk",
+          "tableFrom": "applicant_portal_token",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "applicant_portal_token_token_unique": {
+          "name": "applicant_portal_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applicant_session": {
+      "name": "applicant_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applicant_account_id": {
+          "name": "applicant_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "applicant_session_account_id_idx": {
+          "name": "applicant_session_account_id_idx",
+          "columns": [
+            {
+              "expression": "applicant_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applicant_session_token_idx": {
+          "name": "applicant_session_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applicant_session_applicant_account_id_applicant_account_id_fk": {
+          "name": "applicant_session_applicant_account_id_applicant_account_id_fk",
+          "tableFrom": "applicant_session",
+          "tableTo": "applicant_account",
+          "columnsFrom": [
+            "applicant_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "applicant_session_token_unique": {
+          "name": "applicant_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.activity_action": {
+      "name": "activity_action",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated",
+        "deleted",
+        "status_changed",
+        "comment_added",
+        "member_invited",
+        "member_removed",
+        "member_role_changed",
+        "scored"
+      ]
+    },
+    "public.analysis_run_status": {
+      "name": "analysis_run_status",
+      "schema": "public",
+      "values": [
+        "completed",
+        "failed",
+        "partial"
+      ]
+    },
+    "public.application_status": {
+      "name": "application_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "screening",
+        "interview",
+        "offer",
+        "hired",
+        "rejected"
+      ]
+    },
+    "public.calendar_provider": {
+      "name": "calendar_provider",
+      "schema": "public",
+      "values": [
+        "google"
+      ]
+    },
+    "public.candidate_response": {
+      "name": "candidate_response",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "tentative"
+      ]
+    },
+    "public.comment_target": {
+      "name": "comment_target",
+      "schema": "public",
+      "values": [
+        "candidate",
+        "application",
+        "job"
+      ]
+    },
+    "public.criterion_category": {
+      "name": "criterion_category",
+      "schema": "public",
+      "values": [
+        "technical",
+        "experience",
+        "soft_skills",
+        "education",
+        "culture",
+        "custom"
+      ]
+    },
+    "public.document_type": {
+      "name": "document_type",
+      "schema": "public",
+      "values": [
+        "resume",
+        "cover_letter",
+        "other"
+      ]
+    },
+    "public.interview_status": {
+      "name": "interview_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "cancelled",
+        "no_show"
+      ]
+    },
+    "public.interview_type": {
+      "name": "interview_type",
+      "schema": "public",
+      "values": [
+        "phone",
+        "video",
+        "in_person",
+        "panel",
+        "technical",
+        "take_home"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "open",
+        "closed",
+        "archived"
+      ]
+    },
+    "public.job_type": {
+      "name": "job_type",
+      "schema": "public",
+      "values": [
+        "full_time",
+        "part_time",
+        "contract",
+        "internship"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.question_type": {
+      "name": "question_type",
+      "schema": "public",
+      "values": [
+        "short_text",
+        "long_text",
+        "single_select",
+        "multi_select",
+        "number",
+        "date",
+        "url",
+        "checkbox",
+        "file_upload"
+      ]
+    },
+    "public.source_channel": {
+      "name": "source_channel",
+      "schema": "public",
+      "values": [
+        "linkedin",
+        "indeed",
+        "glassdoor",
+        "ziprecruiter",
+        "monster",
+        "handshake",
+        "angellist",
+        "wellfound",
+        "dice",
+        "stackoverflow",
+        "weworkremotely",
+        "remoteok",
+        "builtin",
+        "hired",
+        "lever",
+        "greenhouse_board",
+        "google_jobs",
+        "facebook",
+        "twitter",
+        "instagram",
+        "tiktok",
+        "reddit",
+        "referral",
+        "career_site",
+        "email",
+        "event",
+        "agency",
+        "direct",
+        "other",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -148,6 +148,20 @@
       "when": 1776076881696,
       "tag": "0020_goofy_grey_gargoyle",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1776080752775,
+      "tag": "0021_blushing_thing",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1776082244843,
+      "tag": "0022_mute_green_goblin",
+      "breakpoints": true
     }
   ]
 }

--- a/server/database/schema/app.ts
+++ b/server/database/schema/app.ts
@@ -92,6 +92,8 @@ export const application = pgTable('application', {
   score: integer('score'),
   notes: text('notes'),
   coverLetterText: text('cover_letter_text'),
+  viewedAt: timestamp('viewed_at'),
+  viewedBy: text('viewed_by').references(() => user.id, { onDelete: 'set null' }),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 }, (t) => ([

--- a/server/database/schema/index.ts
+++ b/server/database/schema/index.ts
@@ -1,3 +1,4 @@
 export * from './auth'
 export * from './app'
 export * from './sso'
+export * from './portal'

--- a/server/database/schema/portal.ts
+++ b/server/database/schema/portal.ts
@@ -1,0 +1,87 @@
+import {
+  pgTable,
+  text,
+  timestamp,
+  index,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core'
+import { relations } from 'drizzle-orm'
+import { organization } from './auth'
+import { application, candidate } from './app'
+
+// ─────────────────────────────────────────────
+// Applicant Portal — Token-based + OAuth Access
+// ─────────────────────────────────────────────
+
+/**
+ * Secure portal access tokens. Generated when an application is submitted.
+ * Each token grants read-only access to a single application's dashboard.
+ * Token is a 64-char cryptographic hex string — NOT the primary key.
+ */
+export const applicantPortalToken = pgTable('applicant_portal_token', {
+  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  token: text('token').notNull().unique(),
+  applicationId: text('application_id').notNull().references(() => application.id, { onDelete: 'cascade' }),
+  candidateId: text('candidate_id').notNull().references(() => candidate.id, { onDelete: 'cascade' }),
+  organizationId: text('organization_id').notNull().references(() => organization.id, { onDelete: 'cascade' }),
+  /** Token expires after 90 days by default */
+  expiresAt: timestamp('expires_at').notNull(),
+  lastAccessedAt: timestamp('last_accessed_at'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+}, (t) => ([
+  index('portal_token_application_id_idx').on(t.applicationId),
+  index('portal_token_candidate_id_idx').on(t.candidateId),
+  index('portal_token_organization_id_idx').on(t.organizationId),
+  index('portal_token_token_idx').on(t.token),
+]))
+
+/**
+ * Applicant portal accounts — separate from recruiter users.
+ * Created when an applicant signs in with Google to save their dashboard.
+ * Linked to candidate records via email matching.
+ */
+export const applicantAccount = pgTable('applicant_account', {
+  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  googleId: text('google_id').notNull().unique(),
+  email: text('email').notNull(),
+  name: text('name'),
+  image: text('image'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+}, (t) => ([
+  index('applicant_account_email_idx').on(t.email),
+  uniqueIndex('applicant_account_google_id_idx').on(t.googleId),
+]))
+
+/**
+ * Applicant portal sessions — lightweight session management for portal access.
+ * Separate from Better Auth sessions (which are for recruiters).
+ */
+export const applicantSession = pgTable('applicant_session', {
+  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  applicantAccountId: text('applicant_account_id').notNull().references(() => applicantAccount.id, { onDelete: 'cascade' }),
+  token: text('token').notNull().unique(),
+  expiresAt: timestamp('expires_at').notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+}, (t) => ([
+  index('applicant_session_account_id_idx').on(t.applicantAccountId),
+  index('applicant_session_token_idx').on(t.token),
+]))
+
+// ─────────────────────────────────────────────
+// Relations
+// ─────────────────────────────────────────────
+
+export const applicantPortalTokenRelations = relations(applicantPortalToken, ({ one }) => ({
+  application: one(application, { fields: [applicantPortalToken.applicationId], references: [application.id] }),
+  candidate: one(candidate, { fields: [applicantPortalToken.candidateId], references: [candidate.id] }),
+  organization: one(organization, { fields: [applicantPortalToken.organizationId], references: [organization.id] }),
+}))
+
+export const applicantAccountRelations = relations(applicantAccount, ({ many }) => ({
+  sessions: many(applicantSession),
+}))
+
+export const applicantSessionRelations = relations(applicantSession, ({ one }) => ({
+  account: one(applicantAccount, { fields: [applicantSession.applicantAccountId], references: [applicantAccount.id] }),
+}))

--- a/server/utils/portal-auth.ts
+++ b/server/utils/portal-auth.ts
@@ -1,0 +1,150 @@
+import { eq, and } from 'drizzle-orm'
+import { applicantPortalToken, applicantSession, applicantAccount } from '../database/schema'
+
+const TOKEN_EXPIRY_DAYS = 90
+const SESSION_EXPIRY_HOURS = 72
+
+/**
+ * Generate a cryptographically secure portal access token.
+ * Returns a 64-character hex string.
+ */
+export function generatePortalToken(): string {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+/**
+ * Create a portal token for a given application.
+ * Called during the apply flow after a successful submission.
+ */
+export async function createPortalToken(
+  applicationId: string,
+  candidateId: string,
+  organizationId: string,
+): Promise<string> {
+  const token = generatePortalToken()
+  const expiresAt = new Date()
+  expiresAt.setDate(expiresAt.getDate() + TOKEN_EXPIRY_DAYS)
+
+  await db.insert(applicantPortalToken).values({
+    token,
+    applicationId,
+    candidateId,
+    organizationId,
+    expiresAt,
+  })
+
+  return token
+}
+
+/**
+ * Validate a portal token and return the associated data.
+ * Returns null if the token is invalid or expired.
+ * Updates lastAccessedAt on valid access.
+ */
+export async function validatePortalToken(token: string) {
+  const record = await db.query.applicantPortalToken.findFirst({
+    where: eq(applicantPortalToken.token, token),
+    columns: {
+      id: true,
+      applicationId: true,
+      candidateId: true,
+      organizationId: true,
+      expiresAt: true,
+    },
+  })
+
+  if (!record) return null
+  if (record.expiresAt < new Date()) return null
+
+  // Update last accessed (fire-and-forget)
+  db.update(applicantPortalToken)
+    .set({ lastAccessedAt: new Date() })
+    .where(eq(applicantPortalToken.id, record.id))
+    .catch(() => {})
+
+  return record
+}
+
+/**
+ * Create a session for an authenticated applicant account.
+ */
+export async function createApplicantSession(accountId: string): Promise<string> {
+  const token = generatePortalToken()
+  const expiresAt = new Date()
+  expiresAt.setTime(expiresAt.getTime() + SESSION_EXPIRY_HOURS * 60 * 60 * 1000)
+
+  await db.insert(applicantSession).values({
+    applicantAccountId: accountId,
+    token,
+    expiresAt,
+  })
+
+  return token
+}
+
+/**
+ * Validate an applicant session token (from cookie).
+ * Returns the applicant account or null.
+ */
+export async function validateApplicantSession(sessionToken: string) {
+  const session = await db.query.applicantSession.findFirst({
+    where: and(
+      eq(applicantSession.token, sessionToken),
+    ),
+    with: {
+      account: true,
+    },
+  })
+
+  if (!session) return null
+  if (session.expiresAt < new Date()) {
+    // Cleanup expired session
+    db.delete(applicantSession)
+      .where(eq(applicantSession.id, session.id))
+      .catch(() => {})
+    return null
+  }
+
+  return session.account
+}
+
+/**
+ * Find or create an applicant account from Google OAuth profile.
+ */
+export async function findOrCreateApplicantAccount(profile: {
+  googleId: string
+  email: string
+  name?: string
+  image?: string
+}) {
+  let account = await db.query.applicantAccount.findFirst({
+    where: eq(applicantAccount.googleId, profile.googleId),
+  })
+
+  if (account) {
+    // Update profile data on each login
+    const [updated] = await db
+      .update(applicantAccount)
+      .set({
+        email: profile.email,
+        name: profile.name ?? account.name,
+        image: profile.image ?? account.image,
+        updatedAt: new Date(),
+      })
+      .where(eq(applicantAccount.id, account.id))
+      .returning()
+    return updated!
+  }
+
+  // Check if email already has an account (different google ID — shouldn't happen, but guard)
+  const [created] = await db.insert(applicantAccount).values({
+    googleId: profile.googleId,
+    email: profile.email,
+    name: profile.name,
+    image: profile.image,
+  }).returning()
+
+  return created!
+}

--- a/server/utils/portal-dashboard.ts
+++ b/server/utils/portal-dashboard.ts
@@ -1,0 +1,399 @@
+import { eq, and, desc, asc } from 'drizzle-orm'
+import {
+  application,
+  job,
+  candidate,
+  interview,
+  organization,
+  document,
+  activityLog,
+  applicationStatusEnum,
+} from '../database/schema'
+
+/**
+ * Pipeline stage definitions with human-friendly labels and descriptions.
+ * Used to show applicants where they are in the process.
+ */
+const PIPELINE_STAGES = [
+  { key: 'new', label: 'Applied', description: 'Your application has been received and is in the queue.' },
+  { key: 'screening', label: 'Screening', description: 'A recruiter is reviewing your application and qualifications.' },
+  { key: 'interview', label: 'Interview', description: 'You\'ve been selected for an interview stage.' },
+  { key: 'offer', label: 'Offer', description: 'An offer is being prepared or has been extended to you.' },
+  { key: 'hired', label: 'Hired', description: 'Congratulations! You\'ve been hired.' },
+] as const
+
+/**
+ * Fetch complete dashboard data for a single application.
+ * Used by both token-based and authenticated portal endpoints.
+ *
+ * All data is READ-ONLY — no mutations happen in this function.
+ * Sensitive internal data (notes, scores, internal comments) is excluded.
+ */
+export async function getApplicationDashboard(
+  applicationId: string,
+  candidateId: string,
+  organizationId: string,
+) {
+  // Fetch application with job and organization in parallel
+  const [app, org, interviews, documents, statusHistory] = await Promise.all([
+    db.query.application.findFirst({
+      where: and(
+        eq(application.id, applicationId),
+        eq(application.candidateId, candidateId),
+        eq(application.organizationId, organizationId),
+      ),
+      columns: {
+        id: true,
+        status: true,
+        viewedAt: true,
+        createdAt: true,
+        updatedAt: true,
+        // Explicitly exclude sensitive fields
+        // notes: excluded
+        // score: excluded
+      },
+      with: {
+        job: {
+          columns: {
+            id: true,
+            title: true,
+            location: true,
+            type: true,
+            status: true,
+            remoteStatus: true,
+          },
+        },
+      },
+    }),
+
+    db.query.organization.findFirst({
+      where: eq(organization.id, organizationId),
+      columns: {
+        name: true,
+        logo: true,
+      },
+    }),
+
+    // Upcoming & past interviews (only applicant-visible fields)
+    db.query.interview.findMany({
+      where: and(
+        eq(interview.applicationId, applicationId),
+        eq(interview.organizationId, organizationId),
+      ),
+      columns: {
+        id: true,
+        title: true,
+        type: true,
+        status: true,
+        scheduledAt: true,
+        duration: true,
+        location: true,
+        timezone: true,
+        candidateResponse: true,
+        // Exclude: notes, interviewers (internal)
+      },
+      orderBy: [asc(interview.scheduledAt)],
+    }),
+
+    // Uploaded documents (names only — no download links)
+    db.select({
+      id: document.id,
+      type: document.type,
+      originalFilename: document.originalFilename,
+      createdAt: document.createdAt,
+    })
+      .from(document)
+      .where(and(
+        eq(document.candidateId, candidateId),
+        eq(document.organizationId, organizationId),
+      ))
+      .orderBy(desc(document.createdAt)),
+
+    // Status change history from activity log
+    db.select({
+      id: activityLog.id,
+      action: activityLog.action,
+      metadata: activityLog.metadata,
+      createdAt: activityLog.createdAt,
+    })
+      .from(activityLog)
+      .where(and(
+        eq(activityLog.organizationId, organizationId),
+        eq(activityLog.resourceType, 'application'),
+        eq(activityLog.resourceId, applicationId),
+      ))
+      .orderBy(desc(activityLog.createdAt))
+      .limit(50),
+  ])
+
+  if (!app) return null
+
+  // Build pipeline progress
+  const currentStatus = app.status
+  const isRejected = currentStatus === 'rejected'
+  const currentIndex = PIPELINE_STAGES.findIndex((s) => s.key === currentStatus)
+  const pipeline = PIPELINE_STAGES.map((stage, index) => ({
+    ...stage,
+    status: isRejected
+      ? 'inactive' as const
+      : index < currentIndex
+        ? 'completed' as const
+        : index === currentIndex
+          ? 'current' as const
+          : 'upcoming' as const,
+  }))
+
+  // Build timeline from activity log + application creation
+  const timeline = [
+    {
+      id: 'applied',
+      type: 'status_change' as const,
+      title: 'Application Submitted',
+      description: `You applied for ${app.job.title}`,
+      date: app.createdAt,
+    },
+    // Viewed by hiring team entry
+    ...(app.viewedAt
+      ? [{
+          id: 'viewed',
+          type: 'status_change' as const,
+          title: 'Viewed by Hiring Team',
+          description: 'A member of the hiring team reviewed your application.',
+          date: app.viewedAt,
+        }]
+      : []),
+    ...statusHistory
+      .filter((entry) => entry.action === 'status_changed')
+      .map((entry) => {
+        const meta = entry.metadata as Record<string, unknown> | null
+        const to = meta?.to as string | undefined
+        const from = meta?.from as string | undefined
+        return {
+          id: entry.id,
+          type: 'status_change' as const,
+          title: getStatusChangeTitle(from, to),
+          description: getStatusChangeDescription(to),
+          date: entry.createdAt,
+        }
+      }),
+    ...interviews.map((iv) => ({
+      id: iv.id,
+      type: 'interview' as const,
+      title: iv.title,
+      description: `${formatInterviewType(iv.type)} scheduled`,
+      date: iv.scheduledAt,
+    })),
+  ].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+
+  // Separate upcoming vs past interviews
+  const now = new Date()
+  const upcomingInterviews = interviews.filter(
+    (iv) => new Date(iv.scheduledAt) > now && iv.status === 'scheduled',
+  )
+  const pastInterviews = interviews.filter(
+    (iv) => new Date(iv.scheduledAt) <= now || iv.status !== 'scheduled',
+  )
+
+  return {
+    application: {
+      id: app.id,
+      status: app.status,
+      appliedAt: app.createdAt,
+      lastUpdated: app.updatedAt,
+      viewedAt: app.viewedAt,
+      isRejected,
+    },
+    job: {
+      title: app.job.title,
+      location: app.job.location,
+      type: formatJobType(app.job.type),
+      remoteStatus: app.job.remoteStatus,
+      isOpen: app.job.status === 'open',
+    },
+    organization: {
+      name: org?.name ?? 'Unknown',
+      logo: org?.logo,
+    },
+    pipeline,
+    timeline,
+    upcomingInterviews: upcomingInterviews.map(formatInterview),
+    pastInterviews: pastInterviews.map(formatInterview),
+    documents: documents.map((doc) => ({
+      id: doc.id,
+      type: doc.type,
+      filename: doc.originalFilename,
+      uploadedAt: doc.createdAt,
+    })),
+  }
+}
+
+/**
+ * Fetch all applications for a candidate email (authenticated portal).
+ */
+export async function getApplicantDashboardByEmail(email: string) {
+  const candidates = await db.query.candidate.findMany({
+    where: eq(candidate.email, email.toLowerCase()),
+    columns: { id: true, organizationId: true },
+  })
+
+  if (candidates.length === 0) return []
+
+  const applications = []
+
+  for (const cand of candidates) {
+    const apps = await db.query.application.findMany({
+      where: and(
+        eq(application.candidateId, cand.id),
+        eq(application.organizationId, cand.organizationId),
+      ),
+      columns: {
+        id: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+      with: {
+        job: {
+          columns: {
+            id: true,
+            title: true,
+            location: true,
+            type: true,
+            status: true,
+            remoteStatus: true,
+          },
+        },
+      },
+      orderBy: [desc(application.createdAt)],
+    })
+
+    if (apps.length === 0) continue
+
+    // Get org details
+    const org = await db.query.organization.findFirst({
+      where: eq(organization.id, cand.organizationId),
+      columns: { name: true, logo: true },
+    })
+
+    for (const app of apps) {
+      const currentStatus = app.status
+      const isRejected = currentStatus === 'rejected'
+      const currentIndex = PIPELINE_STAGES.findIndex((s) => s.key === currentStatus)
+      const pipeline = PIPELINE_STAGES.map((stage, index) => ({
+        ...stage,
+        status: isRejected
+          ? 'inactive' as const
+          : index < currentIndex
+            ? 'completed' as const
+            : index === currentIndex
+              ? 'current' as const
+              : 'upcoming' as const,
+      }))
+
+      // Count upcoming interviews
+      const interviews = await db.query.interview.findMany({
+        where: and(
+          eq(interview.applicationId, app.id),
+          eq(interview.organizationId, cand.organizationId),
+          eq(interview.status, 'scheduled'),
+        ),
+        columns: { id: true, scheduledAt: true },
+      })
+
+      const upcomingCount = interviews.filter(
+        (iv) => new Date(iv.scheduledAt) > new Date(),
+      ).length
+
+      applications.push({
+        id: app.id,
+        candidateId: cand.id,
+        organizationId: cand.organizationId,
+        status: app.status,
+        appliedAt: app.createdAt,
+        lastUpdated: app.updatedAt,
+        isRejected,
+        job: {
+          title: app.job.title,
+          location: app.job.location,
+          type: formatJobType(app.job.type),
+          remoteStatus: app.job.remoteStatus,
+        },
+        organization: {
+          name: org?.name ?? 'Unknown',
+          logo: org?.logo,
+        },
+        pipeline,
+        upcomingInterviewCount: upcomingCount,
+      })
+    }
+  }
+
+  return applications
+}
+
+// ─── Formatting Helpers ────────────────────────────────
+
+function formatJobType(type: string): string {
+  const map: Record<string, string> = {
+    full_time: 'Full Time',
+    part_time: 'Part Time',
+    contract: 'Contract',
+    internship: 'Internship',
+  }
+  return map[type] ?? type
+}
+
+function formatInterviewType(type: string): string {
+  const map: Record<string, string> = {
+    phone: 'Phone Screen',
+    video: 'Video Call',
+    in_person: 'In-Person',
+    panel: 'Panel Interview',
+    technical: 'Technical Interview',
+    take_home: 'Take-Home Assessment',
+  }
+  return map[type] ?? type
+}
+
+function formatInterview(iv: {
+  id: string
+  title: string
+  type: string
+  status: string
+  scheduledAt: Date
+  duration: number
+  location: string | null
+  timezone: string
+  candidateResponse: string
+}) {
+  return {
+    id: iv.id,
+    title: iv.title,
+    type: formatInterviewType(iv.type),
+    status: iv.status,
+    scheduledAt: iv.scheduledAt,
+    duration: iv.duration,
+    location: iv.location,
+    timezone: iv.timezone,
+    candidateResponse: iv.candidateResponse,
+  }
+}
+
+function getStatusChangeTitle(from: string | undefined, to: string | undefined): string {
+  if (to === 'rejected') return 'Application Not Moving Forward'
+  if (to === 'hired') return 'You\'re Hired!'
+  if (to === 'offer') return 'Offer Extended'
+  if (to === 'interview') return 'Moving to Interview'
+  if (to === 'screening') return 'Under Review'
+  if (to === 'new' && from === 'rejected') return 'Application Reopened'
+  return `Status Updated`
+}
+
+function getStatusChangeDescription(to: string | undefined): string {
+  if (to === 'rejected') return 'The team has decided not to proceed with your application at this time.'
+  if (to === 'hired') return 'Congratulations! The team has extended a hire. Expect to hear from them shortly.'
+  if (to === 'offer') return 'Great news! An offer is being prepared for you.'
+  if (to === 'interview') return 'The team would like to interview you. Watch for scheduling details.'
+  if (to === 'screening') return 'A recruiter is now reviewing your qualifications.'
+  return 'Your application status has been updated.'
+}


### PR DESCRIPTION
- Added schema for applicant portal including tables for tokens, accounts, and sessions.
- Implemented functions for generating and validating portal tokens.
- Created utilities for managing applicant sessions and accounts via Google OAuth.
- Developed dashboard functionality to fetch application data for candidates.
- Included helpers for formatting job types and interview details.

## Summary

- What does this PR change?
- Why is this needed?

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Validation

- [ ] I tested locally
- [ ] I added/updated relevant documentation
- [ ] I verified multi-tenant scoping and auth behavior for affected API paths

## DCO

- [ ] All commits in this PR are signed off (`Signed-off-by`) via `git commit -s`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced candidate application portal with personalized dashboard to track application status, upcoming interviews, documents, and activity timeline.
  * Added Google sign-in authentication for secure portal access.
  * Enabled shareable application tracking links for candidates without requiring login.

* **Bug Fixes**
  * Recruiters can now see when they first viewed an application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->