### PR TITLE
feat: implement forgot password and reset password functionality

### DIFF
--- a/app/pages/auth/forgot-password.vue
+++ b/app/pages/auth/forgot-password.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+definePageMeta({
+    layout: "auth",
+    middleware: ["guest"],
+});
+
+useSeoMeta({
+    title: "Forgot Password — Reqcore",
+    description: "Reset your Reqcore account password",
+    robots: "noindex, nofollow",
+});
+
+const email = ref("");
+const error = ref("");
+const success = ref(false);
+const isLoading = ref(false);
+const localePath = useLocalePath();
+const { track } = useTrack();
+
+onMounted(() => track("forgot_password_page_viewed"));
+
+async function handleRequestReset() {
+    error.value = "";
+
+    if (!email.value) {
+        error.value = "Email is required.";
+        return;
+    }
+
+    isLoading.value = true;
+
+    try {
+        const result = await authClient.forgetPassword({
+            email: email.value,
+            redirectTo: `${window.location.origin}${localePath("/auth/reset-password")}`,
+        });
+
+        if (result.error) {
+            error.value =
+                result.error.message ?? "Failed to send reset email. Please try again.";
+            isLoading.value = false;
+            return;
+        }
+    } catch (e: unknown) {
+        error.value =
+            e instanceof Error ? e.message : "Failed to send reset email. Please try again.";
+        isLoading.value = false;
+        return;
+    }
+
+    track("forgot_password_submitted");
+
+    // Always show success to prevent email enumeration
+    success.value = true;
+    isLoading.value = false;
+}
+</script>
+
+<template>
+    <div class="flex flex-col gap-4">
+        <h2
+            class="text-xl font-semibold text-center text-surface-900 dark:text-surface-100 mb-2"
+        >
+            Reset your password
+        </h2>
+
+        <template v-if="success">
+            <div
+                class="rounded-md border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950 p-3 text-sm text-green-700 dark:text-green-400"
+            >
+                If an account with that email exists, we've sent a password reset link.
+                Please check your inbox and spam folder.
+            </div>
+
+            <p class="text-center text-sm text-surface-500 dark:text-surface-400 mt-2">
+                <NuxtLink
+                    :to="$localePath('/auth/sign-in')"
+                    class="text-brand-600 dark:text-brand-400 hover:underline"
+                >
+                    Back to sign in
+                </NuxtLink>
+            </p>
+        </template>
+
+        <template v-else>
+            <p class="text-sm text-surface-500 dark:text-surface-400 text-center">
+                Enter your email address and we'll send you a link to reset your password.
+            </p>
+
+            <div
+                v-if="error"
+                class="rounded-md border border-danger-200 dark:border-danger-800 bg-danger-50 dark:bg-danger-950 p-3 text-sm text-danger-700 dark:text-danger-400"
+            >
+                {{ error }}
+            </div>
+
+            <form class="flex flex-col gap-4" @submit.prevent="handleRequestReset">
+                <label
+                    class="flex flex-col gap-1 text-sm font-medium text-surface-700 dark:text-surface-300"
+                >
+                    <span>Email</span>
+                    <input
+                        v-model="email"
+                        type="email"
+                        autocomplete="email"
+                        required
+                        class="px-3 py-2 border border-surface-300 dark:border-surface-700 rounded-md text-sm text-surface-900 dark:text-surface-100 bg-white dark:bg-surface-800 outline-none transition-colors focus:border-brand-500 focus:ring-2 focus:ring-brand-500/15"
+                    />
+                </label>
+
+                <button
+                    type="submit"
+                    :disabled="isLoading"
+                    class="mt-2 px-4 py-2.5 bg-brand-600 text-white rounded-md text-sm font-medium cursor-pointer hover:bg-brand-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+                >
+                    {{ isLoading ? "Sending…" : "Send reset link" }}
+                </button>
+            </form>
+
+            <p class="text-center text-sm text-surface-500 dark:text-surface-400">
+                Remember your password?
+                <NuxtLink
+                    :to="$localePath('/auth/sign-in')"
+                    class="text-brand-600 dark:text-brand-400 hover:underline"
+                >
+                    Sign in
+                </NuxtLink>
+            </p>
+        </template>
+    </div>
+</template>

--- a/app/pages/auth/forgot-password.vue
+++ b/app/pages/auth/forgot-password.vue
@@ -30,7 +30,7 @@ async function handleRequestReset() {
     isLoading.value = true;
 
     try {
-        const result = await authClient.forgetPassword({
+        const result = await authClient.requestPasswordReset({
             email: email.value,
             redirectTo: `${window.location.origin}${localePath("/auth/reset-password")}`,
         });

--- a/app/pages/auth/reset-password.vue
+++ b/app/pages/auth/reset-password.vue
@@ -1,0 +1,173 @@
+<script setup lang="ts">
+definePageMeta({
+    layout: "auth",
+    middleware: ["guest"],
+});
+
+useSeoMeta({
+    title: "Reset Password — Reqcore",
+    description: "Set a new password for your Reqcore account",
+    robots: "noindex, nofollow",
+});
+
+const route = useRoute();
+const newPassword = ref("");
+const confirmPassword = ref("");
+const error = ref("");
+const success = ref(false);
+const isLoading = ref(false);
+const localePath = useLocalePath();
+const { track } = useTrack();
+
+const token = computed(() => route.query.token as string | undefined);
+const tokenError = computed(() => route.query.error as string | undefined);
+
+onMounted(() => track("reset_password_page_viewed"));
+
+async function handleResetPassword() {
+    error.value = "";
+
+    if (!token.value) {
+        error.value = "Invalid or missing reset token. Please request a new password reset link.";
+        return;
+    }
+
+    if (!newPassword.value) {
+        error.value = "Password is required.";
+        return;
+    }
+
+    if (newPassword.value.length < 8) {
+        error.value = "Password must be at least 8 characters.";
+        return;
+    }
+
+    if (newPassword.value !== confirmPassword.value) {
+        error.value = "Passwords do not match.";
+        return;
+    }
+
+    isLoading.value = true;
+
+    try {
+        const result = await authClient.resetPassword({
+            newPassword: newPassword.value,
+            token: token.value,
+        });
+
+        if (result.error) {
+            error.value =
+                result.error.message ?? "Failed to reset password. The link may have expired.";
+            isLoading.value = false;
+            return;
+        }
+    } catch (e: unknown) {
+        error.value =
+            e instanceof Error ? e.message : "Failed to reset password. Please try again.";
+        isLoading.value = false;
+        return;
+    }
+
+    track("reset_password_completed");
+    success.value = true;
+    isLoading.value = false;
+}
+</script>
+
+<template>
+    <div class="flex flex-col gap-4">
+        <h2
+            class="text-xl font-semibold text-center text-surface-900 dark:text-surface-100 mb-2"
+        >
+            Set new password
+        </h2>
+
+        <template v-if="success">
+            <div
+                class="rounded-md border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950 p-3 text-sm text-green-700 dark:text-green-400"
+            >
+                Your password has been reset successfully.
+            </div>
+
+            <NuxtLink
+                :to="$localePath('/auth/sign-in')"
+                class="mt-2 px-4 py-2.5 bg-brand-600 text-white rounded-md text-sm font-medium cursor-pointer hover:bg-brand-700 transition-colors text-center block"
+            >
+                Sign in with new password
+            </NuxtLink>
+        </template>
+
+        <template v-else-if="tokenError || !token">
+            <div
+                class="rounded-md border border-danger-200 dark:border-danger-800 bg-danger-50 dark:bg-danger-950 p-3 text-sm text-danger-700 dark:text-danger-400"
+            >
+                {{ tokenError === 'INVALID_TOKEN'
+                    ? "This password reset link is invalid or has expired."
+                    : "Invalid password reset link. Please request a new one." }}
+            </div>
+
+            <NuxtLink
+                :to="$localePath('/auth/forgot-password')"
+                class="mt-2 px-4 py-2.5 bg-brand-600 text-white rounded-md text-sm font-medium cursor-pointer hover:bg-brand-700 transition-colors text-center block"
+            >
+                Request new reset link
+            </NuxtLink>
+        </template>
+
+        <template v-else>
+            <div
+                v-if="error"
+                class="rounded-md border border-danger-200 dark:border-danger-800 bg-danger-50 dark:bg-danger-950 p-3 text-sm text-danger-700 dark:text-danger-400"
+            >
+                {{ error }}
+            </div>
+
+            <form class="flex flex-col gap-4" @submit.prevent="handleResetPassword">
+                <label
+                    class="flex flex-col gap-1 text-sm font-medium text-surface-700 dark:text-surface-300"
+                >
+                    <span>New password</span>
+                    <input
+                        v-model="newPassword"
+                        type="password"
+                        autocomplete="new-password"
+                        required
+                        minlength="8"
+                        class="px-3 py-2 border border-surface-300 dark:border-surface-700 rounded-md text-sm text-surface-900 dark:text-surface-100 bg-white dark:bg-surface-800 outline-none transition-colors focus:border-brand-500 focus:ring-2 focus:ring-brand-500/15"
+                    />
+                </label>
+
+                <label
+                    class="flex flex-col gap-1 text-sm font-medium text-surface-700 dark:text-surface-300"
+                >
+                    <span>Confirm new password</span>
+                    <input
+                        v-model="confirmPassword"
+                        type="password"
+                        autocomplete="new-password"
+                        required
+                        minlength="8"
+                        class="px-3 py-2 border border-surface-300 dark:border-surface-700 rounded-md text-sm text-surface-900 dark:text-surface-100 bg-white dark:bg-surface-800 outline-none transition-colors focus:border-brand-500 focus:ring-2 focus:ring-brand-500/15"
+                    />
+                </label>
+
+                <button
+                    type="submit"
+                    :disabled="isLoading"
+                    class="mt-2 px-4 py-2.5 bg-brand-600 text-white rounded-md text-sm font-medium cursor-pointer hover:bg-brand-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+                >
+                    {{ isLoading ? "Resetting…" : "Reset password" }}
+                </button>
+            </form>
+
+            <p class="text-center text-sm text-surface-500 dark:text-surface-400">
+                <NuxtLink
+                    :to="$localePath('/auth/sign-in')"
+                    class="text-brand-600 dark:text-brand-400 hover:underline"
+                >
+                    Back to sign in
+                </NuxtLink>
+            </p>
+        </template>
+    </div>
+</template>

--- a/app/pages/auth/sign-in.vue
+++ b/app/pages/auth/sign-in.vue
@@ -322,6 +322,15 @@ async function handleSocialSignIn(providerId: string) {
             />
         </label>
 
+        <div class="flex justify-end -mt-2">
+            <NuxtLink
+                :to="$localePath('/auth/forgot-password')"
+                class="text-sm text-brand-600 dark:text-brand-400 hover:underline"
+            >
+                Forgot password?
+            </NuxtLink>
+        </div>
+
         <button
             type="submit"
             :disabled="isLoading"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -251,7 +251,6 @@ export default defineNuxtConfig({
           "X-Content-Type-Options": "nosniff",
           "X-Frame-Options": "DENY",
           "Referrer-Policy": "strict-origin-when-cross-origin",
-          "X-XSS-Protection": "1; mode=block",
           "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
           "Strict-Transport-Security":
             "max-age=63072000; includeSubDomains; preload",

--- a/server/api/sso/providers.post.ts
+++ b/server/api/sso/providers.post.ts
@@ -3,12 +3,49 @@ import { eq, and, ne } from 'drizzle-orm'
 import { ssoProvider } from '~~/server/database/schema'
 import { prefetchOidcEndpointOrigins } from '~~/server/utils/auth'
 
+// Hostname/IP ranges that must never be contacted server-side (SSRF prevention)
+const BLOCKED_ISSUER_HOSTNAMES = new Set([
+  'localhost',
+  '169.254.169.254',          // AWS / Azure / DigitalOcean IMDS
+  'metadata.google.internal', // GCP IMDS
+  'metadata.internal',
+  'instance-data',
+])
+
+function isBlockedIssuerUrl(url: string): boolean {
+  let hostname: string
+  try {
+    hostname = new URL(url).hostname.toLowerCase()
+  } catch {
+    return true
+  }
+  if (BLOCKED_ISSUER_HOSTNAMES.has(hostname)) return true
+  const ipv4 = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+  if (ipv4) {
+    const [a, b] = [Number(ipv4[1]), Number(ipv4[2])]
+    if (a === 127 || a === 0) return true
+    if (a === 10) return true
+    if (a === 172 && b >= 16 && b <= 31) return true
+    if (a === 192 && b === 168) return true
+    if (a === 100 && b >= 64 && b <= 127) return true
+    if (a === 169 && b === 254) return true
+  }
+  if (hostname === '::1') return true
+  if (hostname.startsWith('fe80:')) return true
+  return false
+}
+
 const registerSsoSchema = z.object({
   providerId: z.string().min(1).max(64).regex(/^[a-z0-9-]+$/, 'Only lowercase alphanumeric and hyphens'),
-  issuer: z.string().url().refine(
-    (url) => url.startsWith('https://') || url.startsWith('http://'),
-    'Issuer URL must use HTTPS (or HTTP for local development)',
-  ),
+  issuer: z.string().url()
+    .refine(
+      (url) => url.startsWith('https://') || url.startsWith('http://'),
+      'Issuer URL must use HTTPS (or HTTP for local development)',
+    )
+    .refine(
+      (url) => !isBlockedIssuerUrl(url),
+      'Issuer URL must not target internal or private network addresses',
+    ),
   domain: z.string().min(1).max(253).regex(
     /^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/,
     'Must be a valid domain (e.g. company.com)',

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -10,6 +10,50 @@ import * as schema from "../database/schema";
 type Auth = ReturnType<typeof betterAuth>;
 let _auth: Auth | undefined;
 
+// ── SSRF blocklist ────────────────────────────────────────────────────────────
+// Prevent org admins from using SSO provider registration to probe the
+// internal network or cloud metadata services (OWASP A10 - SSRF).
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "169.254.169.254",          // AWS / Azure / DigitalOcean IMDS
+  "metadata.google.internal", // GCP IMDS
+  "metadata.internal",
+  "instance-data",            // older cloud-init
+])
+
+/**
+ * Returns true if the hostname resolves to a private, loopback, link-local,
+ * or well-known cloud metadata address that must not be contacted server-side.
+ */
+function isBlockedHost(urlString: string): boolean {
+  let hostname: string
+  try {
+    hostname = new URL(urlString).hostname.toLowerCase()
+  } catch {
+    return true // malformed URL → block
+  }
+  if (BLOCKED_HOSTNAMES.has(hostname)) return true
+
+  // IPv4 private / loopback ranges
+  const ipv4 = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+  if (ipv4) {
+    const [a, b] = [Number(ipv4[1]), Number(ipv4[2])]
+    if (a === 127) return true                          // 127.0.0.0/8  loopback
+    if (a === 0) return true                            // 0.0.0.0/8
+    if (a === 10) return true                           // 10.0.0.0/8   RFC 1918
+    if (a === 172 && b >= 16 && b <= 31) return true   // 172.16.0.0/12 RFC 1918
+    if (a === 192 && b === 168) return true             // 192.168.0.0/16 RFC 1918
+    if (a === 100 && b >= 64 && b <= 127) return true  // 100.64.0.0/10 CGNAT
+    if (a === 169 && b === 254) return true             // 169.254.0.0/16 link-local
+  }
+
+  // IPv6 loopback and link-local
+  if (hostname === "::1") return true
+  if (hostname.startsWith("fe80:") || hostname.startsWith("[fe80:")) return true
+
+  return false
+}
+
 /**
  * Fetch an OIDC discovery document and inject every endpoint origin into
  * better-auth's live trusted-origins list so the SSO plugin trusts them
@@ -25,6 +69,14 @@ let _auth: Auth | undefined;
  * Must be called **before** `auth.api.registerSSOProvider()`.
  */
 export async function prefetchOidcEndpointOrigins(issuerUrl: string): Promise<void> {
+  // SSRF guard — reject internal/private addresses before any network call
+  if (isBlockedHost(issuerUrl)) {
+    throw createError({
+      statusCode: 422,
+      statusMessage: "Issuer URL must not target internal or private network addresses.",
+    })
+  }
+
   const discoveryUrl = issuerUrl.replace(/\/+$/, "") + "/.well-known/openid-configuration";
   const res = await $fetch<Record<string, unknown>>(discoveryUrl, {
     timeout: 10_000,

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -74,7 +74,7 @@ export async function prefetchOidcEndpointOrigins(issuerUrl: string): Promise<vo
     throw createError({
       statusCode: 422,
       statusMessage: "Issuer URL must not target internal or private network addresses.",
-    })
+    });
   }
 
   const discoveryUrl = issuerUrl.replace(/\/+$/, "") + "/.well-known/openid-configuration";

--- a/server/utils/resume-parser.ts
+++ b/server/utils/resume-parser.ts
@@ -99,6 +99,8 @@ export async function parseDocument(
 // ─── PDF Parser ───────────────────────────────────────────────────
 
 async function parsePdf(buffer: Buffer): Promise<ParsedResume | null> {
+  if (buffer.length === 0) return null
+
   // Polyfill browser globals before pdfjs-dist evaluates its module-level code
   ensurePdfjsPolyfills()
   const { PDFParse } = await import('pdf-parse')


### PR DESCRIPTION
## Summary
This pull request introduces a complete password reset flow for users, including both "forgot password" and "reset password" pages, and adds a link to the "forgot password" page on the sign-in screen. The new pages provide user-friendly forms, error handling, and tracking, while following security best practices such as preventing email enumeration.

**Password reset flow implementation:**

* Added a new `forgot-password.vue` page that allows users to request a password reset link by entering their email. The page includes form validation, error handling, success messaging, and tracking of user actions.
* Added a new `reset-password.vue` page that lets users set a new password using a reset token. The page handles token validation, password validation, error and success messaging, and tracks relevant events.

**Sign-in page update:**

* Added a "Forgot password?" link to the sign-in page (`sign-in.vue`), directing users to the new password reset flow.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Validation

- [x] I tested locally
- [ ] I added/updated relevant documentation
- [ ] I verified multi-tenant scoping and auth behavior for affected API paths

## DCO

- [ ] All commits in this PR are signed off (`Signed-off-by`) via `git commit -s`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password recovery flow: request a reset by email and set a new password via secure reset link.
  * "Forgot password?" link added to the sign-in page.

* **Bug Fixes**
  * Resumes: empty PDF uploads are now handled gracefully without errors.

* **Security**
  * Improved server-side protections for external identity provider endpoints to reduce request-based abuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->