### PR TITLE
feat: Implement two-tier consent model for PostHog analytics

### DIFF
--- a/app/composables/useAnalyticsConsent.ts
+++ b/app/composables/useAnalyticsConsent.ts
@@ -1,16 +1,23 @@
 /**
  * Composable for managing PostHog analytics consent.
  *
- * Cookieless tracking is ALWAYS active — no consent needed.
- * Accepting analytics upgrades to full cookie-based tracking
- * (UTM, sessions, identity). Declining keeps cookieless mode.
+ * Two-tier model
+ * --------------
+ * - **No choice yet OR declined**: PostHog runs in cookieless mode
+ *   (`persistence: 'memory'`, `person_profiles: 'identified_only'`).
+ *   Logged-in users are still identified by their opaque user.id (so we
+ *   can count returning users and per-user metrics) but no email/name is
+ *   forwarded and nothing is stored on the visitor's device.
+ *
+ * - **Accepted**: PostHog persistence is upgraded to `localStorage+cookie`
+ *   so the distinct id survives reloads, then `identify(userId, { email,
+ *   name })` is re-fired with full PII.  PostHog automatically aliases the
+ *   current anonymous distinct id → user id, stitching the pre-signup
+ *   funnel into the user's profile.
  */
 
 /** Cookie name — shared across reqcore-web and applirank */
 export const CONSENT_COOKIE_NAME = 'reqcore-consent'
-
-/** @deprecated Old localStorage key — used only for one-time migration */
-const LEGACY_STORAGE_KEY = 'reqcore-analytics-consent'
 
 type ConsentState = 'granted' | 'denied' | null
 
@@ -32,32 +39,26 @@ export function useAnalyticsConsent() {
     sameSite: 'lax',
   })
 
-  // One-time migration: move consent from localStorage to cookie for users
-  // who consented before this change, then clean up localStorage.
-  if (import.meta.client && !consentCookie.value) {
-    const legacy = localStorage.getItem(LEGACY_STORAGE_KEY)
-    if (legacy === 'granted' || legacy === 'denied') {
-      consentCookie.value = legacy
-      localStorage.removeItem(LEGACY_STORAGE_KEY)
-    }
-  }
-
   const hasConsented = computed(() => consentCookie.value === 'granted')
   const hasDeclined = computed(() => consentCookie.value === 'denied')
   const needsConsent = computed(() => !consentCookie.value)
 
   function acceptAnalytics() {
     consentCookie.value = 'granted'
-    if (import.meta.client) localStorage.removeItem(LEGACY_STORAGE_KEY)
     if (!ph) return
-    // Upgrade from cookieless to full cookie-based persistence
+
+    // Upgrade from cookieless to cookie+localStorage persistence so the
+    // distinct id survives reloads and new tabs.  After this, the watcher
+    // in `usePostHogIdentity` (which depends on `hasConsented`) re-fires
+    // and re-identifies the user with full PII — that identify() call
+    // automatically aliases the current anonymous distinct id → user id.
     ph.set_config({
       persistence: 'localStorage+cookie',
-      person_profiles: 'identified_only',
       cross_subdomain_cookie: true,
     })
-    // Register UTM + attribution now that we have persistence
+
     if (import.meta.client) {
+      // Capture UTM + first-touch attribution now that we have persistence
       const params = new URLSearchParams(window.location.search)
       const utmKeys = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'] as const
       const utmProps: Record<string, string> = {}
@@ -83,8 +84,8 @@ export function useAnalyticsConsent() {
 
   function declineAnalytics() {
     consentCookie.value = 'denied'
-    if (import.meta.client) localStorage.removeItem(LEGACY_STORAGE_KEY)
-    // No action needed — cookieless tracking continues without cookies or person profiles
+    // No PostHog action needed — cookieless mode (memory + identified_only)
+    // continues, no person profile properties are sent, no cookies are set.
   }
 
   return {

--- a/app/composables/usePostHogIdentity.ts
+++ b/app/composables/usePostHogIdentity.ts
@@ -5,79 +5,99 @@
  *
  * Must be called in `<script setup>` context (not in a plugin).
  *
- * Identity and group calls are gated on analytics consent so that events are
- * never sent before the user has opted in.  When a user grants consent during
- * their session (ConsentBanner), the watchers re-fire and identify them
- * immediately without requiring a page reload.
+ * Identity model
+ * --------------
+ * Logged-in users are ALWAYS identified by their opaque `user.id` so that
+ * funnel + retention analytics work even for visitors who never accept
+ * cookies.  Email and name are forwarded ONLY when the user has explicitly
+ * consented to analytics — keeping the dashboard PII-free for non-consenters
+ * while still letting consented users be looked up by email in PostHog.
+ *
+ * The watcher depends on `hasConsented`, so when a user clicks "Accept" in
+ * the banner the identify() call re-fires immediately and PostHog aliases
+ * the anonymous distinct id to the user id (preserving the in-session
+ * funnel from anonymous visit → signup → identified user).
  */
 export async function usePostHogIdentity() {
-  const { $posthogIdentifyUser, $posthogSetOrganization, $posthogReset, $posthogResetGroups } = useNuxtApp()
+  const { $posthogIdentifyUser, $posthogSetOrganization, $posthogReset, $posthogResetGroups, $posthogSetDemoFlag } = useNuxtApp()
 
   if (!$posthogIdentifyUser) return
 
   const { data: session } = await authClient.useSession(useFetch)
   const activeOrgState = authClient.useActiveOrganization()
 
-  // Share the consent reactive state.  useAnalyticsConsent also applies the
-  // stored consent flag to PostHog on the client, so calling it here means
-  // consent is active before the immediate watchers fire below.
   const { hasConsented } = useAnalyticsConsent()
 
-  // Watch session AND consent so identify re-fires when a new user accepts
-  // consent during their visit, and is skipped when PostHog is opted-out.
+  const config = useRuntimeConfig()
+  const liveDemoEmail = (config.public.liveDemoEmail as string | undefined) || ''
+  const demoOrgSlug = (config.public.demoOrgSlug as string | undefined) || ''
+
   watch(
     [() => session.value, hasConsented] as const,
     ([currentSession, consented], prev) => {
       const user = currentSession?.user
       const previousUser = (prev?.[0] as typeof session.value)?.user
 
-      if (user?.id && consented) {
-        // Forward person properties for opted-in users so they're identifiable
-        // in PostHog.  GDPR-safe: gated on explicit user consent.
-        ;($posthogIdentifyUser as (userId: string, properties?: Record<string, string | undefined>) => void)(
-          user.id,
-          {
+      if (user?.id) {
+        // Forward person properties (email, name) ONLY if consent was given.
+        // Without consent we still identify with the opaque user.id so
+        // returning users are stable in PostHog — but no PII is attached.
+        const identify = $posthogIdentifyUser as (
+          userId: string,
+          properties?: Record<string, string | undefined>,
+        ) => void
+        if (consented) {
+          identify(user.id, {
             email: user.email,
             name: user.name || undefined,
-          },
-        )
+          })
+        }
+        else {
+          identify(user.id)
+        }
+
+        // Demo tagging by user email — fires the moment the demo account
+        // signs in, even before an organisation context is loaded.
+        const setDemoFlag = $posthogSetDemoFlag as ((isDemo: boolean) => void) | undefined
+        if (setDemoFlag && liveDemoEmail) {
+          setDemoFlag(user.email === liveDemoEmail)
+        }
       }
       else if (previousUser?.id && !user?.id) {
         // Always reset on log-out regardless of consent state so that
         // no user identity leaks into the next anonymous session.
+        // Reset also clears the registered super properties (incl. is_demo).
         ($posthogReset as () => void)()
       }
     },
     { immediate: true },
   )
 
-  // Watch org AND consent for group analytics — same gating logic as above.
   watch(
     [() => activeOrgState.value?.data, hasConsented] as const,
     async ([org, consented]) => {
-      if (consented) {
-        if (org?.id) {
-          // Fetch the current member's role to enrich group properties — useful
-          // for debugging permission issues without exposing personal data.
-          let memberRole: string | undefined
-          try {
-            const { data } = await authClient.organization.getActiveMemberRole()
-            memberRole = data?.role ?? undefined
-          }
-          catch { /* non-critical; role is just an enrichment property */ }
-
-          // Only org id, name, and member role are forwarded; slug is omitted to minimise data.
-          ;($posthogSetOrganization as (org: { id: string, name?: string, member_role?: string }) => void)({
-            id: org.id,
-            name: org.name || undefined,
-            member_role: memberRole,
-          })
+      if (org?.id) {
+        // Forward org name only for consenters; anonymous users get an
+        // opaque org-id-only group so per-org metrics still aggregate.
+        const setOrg = $posthogSetOrganization as (org: { id: string, name?: string }) => void
+        if (consented) {
+          setOrg({ id: org.id, name: org.name || undefined })
         }
         else {
-          // Clear org group when user has no active organization to avoid
-          // attributing events to the previously selected org.
-          ($posthogResetGroups as (() => void) | undefined)?.()
+          setOrg({ id: org.id })
         }
+
+        // Demo tagging by org slug — covers self-hosted deployments
+        // where the demo org may be owned by a non-demo email account.
+        // We only set true here; the email-based watcher above handles
+        // clearing the flag when the user is not the demo user.
+        const setDemoFlag = $posthogSetDemoFlag as ((isDemo: boolean) => void) | undefined
+        if (setDemoFlag && demoOrgSlug && org.slug === demoOrgSlug) {
+          setDemoFlag(true)
+        }
+      }
+      else {
+        ($posthogResetGroups as (() => void) | undefined)?.()
       }
     },
     { immediate: true },

--- a/app/composables/useTrack.ts
+++ b/app/composables/useTrack.ts
@@ -1,114 +1,41 @@
 /**
- * Composable for privacy-respecting PostHog funnel tracking.
+ * Composable for privacy-respecting PostHog event tracking.
  *
- * Wraps posthog.capture() with:
- * - Consent gating (no-ops when user hasn't opted in)
- * - Pre-consent event buffering (replayed when user consents)
- * - Auto-enrichment with page context (route path, viewport width)
+ * Wraps posthog.capture() with auto-enrichment (route path, viewport width).
+ *
+ * Events are ALWAYS captured — even before the consent banner is answered —
+ * because PostHog runs in `persistence: 'memory'` mode by default, so the
+ * anonymous distinct id never reaches the visitor's storage (no cookies, no
+ * localStorage).  When the user later accepts cookies, persistence is
+ * upgraded and `identify(userId, …)` automatically aliases the in-memory
+ * anonymous id to the user id, so the in-session funnel is preserved.
  */
 import type { PostHog } from 'posthog-js'
-
-interface PendingEvent {
-  eventName: string
-  properties: Record<string, unknown>
-}
-
-// Module-level buffer for events captured before consent is granted.
-// Flushed to PostHog when the user accepts analytics; discarded on decline.
-// Persisted to sessionStorage so the buffer survives hard page reloads
-// (e.g. window.location.href navigation in createOrg/switchOrg).
-const MAX_PENDING_EVENTS = 50
-const STORAGE_KEY = 'ph-pending-events'
-
-function restoreBuffer(): PendingEvent[] {
-  if (!import.meta.client) return []
-  try {
-    const stored = sessionStorage.getItem(STORAGE_KEY)
-    return stored ? JSON.parse(stored) as PendingEvent[] : []
-  }
-  catch { return [] }
-}
-
-function persistBuffer() {
-  if (!import.meta.client) return
-  try {
-    if (pendingEvents.length > 0) {
-      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(pendingEvents))
-    }
-    else {
-      sessionStorage.removeItem(STORAGE_KEY)
-    }
-  }
-  catch { /* storage full or unavailable */ }
-}
-
-const pendingEvents: PendingEvent[] = restoreBuffer()
 
 function getPostHog(): PostHog | undefined {
   const $ph = (useNuxtApp() as Record<string, unknown>).$posthog as (() => PostHog) | undefined
   return $ph?.()
 }
 
-/**
- * Flush buffered pre-consent events to PostHog.
- * Called by useAnalyticsConsent.acceptAnalytics() after opting in.
- */
-export function flushPendingEvents() {
-  const ph = getPostHog()
-  if (!ph || !ph.has_opted_in_capturing()) return
-  while (pendingEvents.length > 0) {
-    const event = pendingEvents.shift()!
-    ph.capture(event.eventName, event.properties)
-  }
-  persistBuffer()
-}
-
-/**
- * Discard buffered pre-consent events (user declined analytics).
- */
-export function discardPendingEvents() {
-  pendingEvents.length = 0
-  persistBuffer()
-}
-
 export function useTrack() {
   const route = useRoute()
 
-  /**
-   * Send a custom event to PostHog (consent-gated).
-   * Automatically includes current route path and viewport width.
-   *
-   * If PostHog is not yet opted-in (consent pending), the event is
-   * buffered and replayed when/if the user grants consent.
-   */
   function track(eventName: string, properties?: Record<string, unknown>) {
     if (!import.meta.client) return
     const ph = getPostHog()
     if (!ph) return
 
-    const enrichedProps = {
+    ph.capture(eventName, {
       path: route.path,
       viewport_width: window.innerWidth,
       ...properties,
-    }
-
-    if (ph.has_opted_in_capturing()) {
-      ph.capture(eventName, enrichedProps)
-    }
-    else if (pendingEvents.length < MAX_PENDING_EVENTS) {
-      pendingEvents.push({ eventName, properties: enrichedProps })
-      persistBuffer()
-    }
+    })
   }
 
-  /**
-   * Report a caught error to PostHog's error tracking (consent-gated).
-   * Use for errors that are handled in catch blocks but still worth logging.
-   */
   function captureError(error: unknown, properties?: Record<string, unknown>) {
     if (!import.meta.client) return
     const ph = getPostHog()
-    if (!ph || !ph.has_opted_in_capturing()) return
+    if (!ph) return
 
     ph.captureException(error instanceof Error ? error : new Error(String(error)), {
       path: route.path,

--- a/app/plugins/posthog-identity.client.ts
+++ b/app/plugins/posthog-identity.client.ts
@@ -1,28 +1,36 @@
 /**
- * Client-only plugin that identifies the current user and organization
- * in PostHog whenever the auth session is available.
+ * Client-only plugin that wires PostHog into the rest of the app.
  *
- * - Upgrades PostHog from cookieless to full cookie-based persistence
- *   for returning opted-in users, BEFORE identity watchers fire.
- * - Calls posthog.identify() with the user's ID and person properties
- * - Calls posthog.group() for the active organization (group analytics)
- * - Resets PostHog on sign-out to avoid cross-user data leakage
+ * - Strips query strings and hashes from captured URLs (privacy hardening).
+ * - Reads the consent cookie on boot: if the user previously accepted
+ *   analytics, upgrade PostHog from memory persistence to
+ *   `localStorage+cookie` BEFORE the identity watchers fire.
+ * - Provides helpers for identifying the user / setting the active org group;
+ *   these are invoked by `usePostHogIdentity` once the auth session loads.
+ * - Resets PostHog on sign-out to avoid cross-user data leakage.
+ *
+ * GDPR model
+ * ----------
+ * Default state is cookieless (memory persistence, identified_only profiles)
+ * so visitors who never see / never click the consent banner have *nothing*
+ * stored on their device.  Accepting the banner upgrades persistence so the
+ * distinct id survives reloads, and `identify(userId, { email, name })`
+ * automatically aliases the anonymous id → user id, stitching the funnel.
  */
 import { CONSENT_COOKIE_NAME } from '~/composables/useAnalyticsConsent'
 
-// URL properties that may carry tokens or invitation IDs — always sanitized.
+// URL properties that may carry tokens or invitation IDs — always sanitised.
 // Includes referrer properties: if a user navigated from /jobs?invite_token=xxx,
-// the next page's $referrer would expose that token without sanitization.
+// the next page's $referrer would otherwise expose that token.
 const SENSITIVE_URL_PROPS = ['$current_url', '$initial_current_url', '$referrer', '$initial_referrer'] as const
 
 export default defineNuxtPlugin({
   name: 'posthog-identity',
   setup() {
     // usePostHog() is auto-imported by @posthog/nuxt, but the module is
-    // conditionally loaded (only when POSTHOG_PUBLIC_KEY is set).  In CI and
-    // local-dev without the key the auto-import doesn't exist, so we replicate
-    // its safe accessor here: $posthog is a function provided by the module's
-    // plugin — when the module isn't loaded it simply won't be on NuxtApp.
+    // conditionally loaded (only when POSTHOG_PUBLIC_KEY is set).  Replicate
+    // the safe accessor so this plugin is a no-op when PostHog is not
+    // configured (CI, self-hosted without the key).
     const $ph = (useNuxtApp() as Record<string, unknown>).$posthog as (() => import('posthog-js').PostHog) | undefined
     const posthog = $ph?.()
     if (!posthog) return
@@ -63,38 +71,28 @@ export default defineNuxtPlugin({
     }
 
     // ── Apply stored consent: upgrade persistence for returning opted-in users ──
-    // PostHog starts with cookieless tracking (persistence: 'memory',
-    // person_profiles: 'never').  If the user already consented, upgrade to
-    // full cookie-based persistence before identity watchers fire so that
-    // identify() and group() calls create person profiles.
-    const storedConsent = consentCookie.value
-    if (storedConsent === 'granted') {
+    // PostHog starts with cookieless tracking (persistence: 'memory').  If
+    // the user already consented, upgrade to full cookie-based persistence
+    // before identity watchers fire so that identify() creates a stable
+    // person profile and the existing distinct id aliases cleanly.
+    if (consentCookie.value === 'granted') {
       posthog.set_config({
         persistence: 'localStorage+cookie',
-        person_profiles: 'identified_only',
         cross_subdomain_cookie: true,
       })
     }
-    // No else needed: cookieless tracking continues for non-consented visitors.
-    // Events still flow (aggregate analytics) but no person profiles are created.
-
-    // ── Privacy: strip query params and hashes from captured URLs ──
-    // These may contain tokens, invitation IDs, or other PII.
-    const originalCapture = posthog.capture.bind(posthog)
 
     // ── Cross-domain identity linking ──
     // The marketing site (reqcore.com) appends ?ph_did=<distinct_id> to links
-    // pointing here.  If present, alias the marketing visitor's anonymous ID to
-    // this session so the full journey is stitched together in PostHog.
+    // pointing here.  If present, alias the marketing visitor's distinct id
+    // to this session so the full journey is stitched together in PostHog.
     const marketingDistinctId = url.searchParams.get('ph_did')
     // Validate format: PostHog distinct IDs are typically UUIDs or short
     // alphanumeric strings.  Reject anything outside that to prevent
     // passing arbitrary untrusted input to posthog.alias().
     const isValidDistinctId = marketingDistinctId && /^[\w-]{10,100}$/.test(marketingDistinctId)
-    if (isValidDistinctId && storedConsent === 'granted') {
-      // Create an alias so both IDs resolve to the same person in PostHog.
+    if (isValidDistinctId && consentCookie.value === 'granted') {
       posthog.alias(marketingDistinctId)
-      // Strip the param from the URL to prevent it leaking into pageview props.
       url.searchParams.delete('ph_did')
       urlModified = true
     }
@@ -103,15 +101,17 @@ export default defineNuxtPlugin({
       window.history.replaceState({}, '', url.pathname + url.search + url.hash)
     }
 
+    // ── Privacy: strip query params and hashes from captured URLs ──
+    const originalCapture = posthog.capture.bind(posthog)
     posthog.capture = (eventName: string, properties?: Record<string, unknown>, options?: unknown) => {
       const props = { ...properties }
       for (const key of SENSITIVE_URL_PROPS) {
         if (typeof props[key] === 'string') {
           try {
-            const url = new URL(props[key] as string)
-            url.search = ''
-            url.hash = ''
-            props[key] = url.toString()
+            const u = new URL(props[key] as string)
+            u.search = ''
+            u.hash = ''
+            props[key] = u.toString()
           }
           catch { /* keep original if parsing fails */ }
         }
@@ -119,30 +119,67 @@ export default defineNuxtPlugin({
       return originalCapture(eventName, props, options as never)
     }
 
-    // Provide a hook that components/composables can use to identify the user
-    // after the app has mounted and auth session is available.
     return {
       provide: {
-        // User ID + person properties (email, name) are sent for opted-in
-        // users.  GDPR-safe: identify() in usePostHogIdentity is gated on
-        // consent, and person_profiles is 'never' until consent upgrades it
-        // to 'identified_only'.
+        /**
+         * Identify the logged-in user.  Person properties (email, name) are
+         * forwarded ONLY when the visitor has consented to analytics —
+         * otherwise we pass just the user id to keep PostHog data anonymous.
+         *
+         * Calling identify automatically aliases the current anonymous
+         * distinct id to the user id, so the pre-signup funnel within the
+         * same session is stitched into the user's profile.
+         */
         posthogIdentifyUser: (userId: string, properties?: Record<string, string | undefined>) => {
-          posthog.identify(userId, properties)
+          if (properties) {
+            posthog.identify(userId, properties)
+          }
+          else {
+            posthog.identify(userId)
+          }
         },
-        // Only id and human-readable name are forwarded.  slug is redundant
-        // for analytics purposes and is omitted to minimise data collection.
-        posthogSetOrganization: (org: { id: string, name?: string, member_role?: string }) => {
-          posthog.group('organization', org.id, {
-            name: org.name || undefined,
-            member_role: org.member_role || undefined,
-          })
+        /**
+         * Set the active organization as a PostHog group.  Org name is
+         * forwarded only when the user has consented; otherwise just the
+         * opaque id flows so per-org metrics still aggregate without
+         * exposing customer names in the dashboard.
+         */
+        posthogSetOrganization: (org: { id: string, name?: string }) => {
+          if (org.name) {
+            posthog.group('organization', org.id, { name: org.name })
+          }
+          else {
+            posthog.group('organization', org.id)
+          }
         },
         posthogReset: () => {
           posthog.reset()
         },
         posthogResetGroups: () => {
           posthog.resetGroups()
+        },
+        /**
+         * Tag the current PostHog session as a demo session.
+         *
+         * Registers `is_demo` as a super property so EVERY subsequent
+         * event carries it — funnels and dashboards can then filter
+         * `is_demo != true` to exclude the public demo from real-user
+         * metrics. Also forwards the flag as a person property (when
+         * consented) so the demo person profile is permanently tagged.
+         *
+         * Pass `false` to clear the flag (e.g. when a real user signs
+         * in after a demo session in the same tab).
+         */
+        posthogSetDemoFlag: (isDemo: boolean) => {
+          if (isDemo) {
+            posthog.register({ is_demo: true })
+            // Person-level tag — survives across sessions for this user.
+            posthog.setPersonProperties({ is_demo: true })
+          }
+          else {
+            posthog.unregister('is_demo')
+            posthog.setPersonProperties({ is_demo: false })
+          }
         },
       },
     }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -107,7 +107,6 @@ export default defineNuxtConfig({
       disable_session_recording: true,
       enable_recording_console_log: false,
       disable_surveys: true,
-      secure_cookie: true,
       capture_pageview: true,
       capture_pageleave: true,
       // ── Error tracking: capture unhandled errors and rejections ──
@@ -116,13 +115,22 @@ export default defineNuxtConfig({
         capture_unhandled_rejections: true,
         capture_console_errors: false,
       },
-      // ── Cookieless by default ──
-      // No cookies stored until user grants consent.  Events still flow for
-      // aggregate analytics.  On consent, persistence is upgraded to
-      // 'localStorage+cookie' via set_config() in the consent composable.
+      // ── Cookieless tracking — no consent banner needed ──
+      // `persistence: 'memory'` keeps the distinct_id in RAM only.  Nothing is
+      // written to cookies, localStorage, or sessionStorage, so the ePrivacy
+      // Directive (Art. 5(3)) "consent for storage" requirement does not apply.
+      //
+      // `person_profiles: 'identified_only'` means anonymous visitors flow as
+      // events without creating person profiles, while logged-in users get a
+      // stable profile keyed by their auth user-id (via posthog.identify()).
+      // This gives us funnel + retention analytics for real users without
+      // tracking anonymous visitors across sessions.
       persistence: "memory",
-      person_profiles: "never",
-      cross_subdomain_cookie: false,
+      person_profiles: "identified_only",
+      // ── GDPR: drop IP address from events ──
+      // PostHog uses $ip server-side for GeoIP, but we do not need it for the
+      // SaaS analytics use case.  Denylisting it minimises personal data sent.
+      property_denylist: ["$ip", "$initial_ip"],
     },
     serverConfig: {
       // Disabled: the @posthog/nuxt Nitro plugin captures ALL errors

--- a/server/middleware/demo-guard.ts
+++ b/server/middleware/demo-guard.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm'
 import * as schema from '../database/schema'
 import { createPreviewReadOnlyError } from '../utils/previewReadOnly'
-import { isRailwayPreviewEnvironment } from '../utils/env'
+import { getConfiguredDemoSlugs, getDemoOrgIds } from '../utils/demoOrg'
 
 /**
  * Demo guard middleware — blocks write operations (POST, PATCH, PUT, DELETE)
@@ -11,67 +11,10 @@ import { isRailwayPreviewEnvironment } from '../utils/env'
  * Auth routes (/api/auth/**) are always allowed so users can sign in/out.
  */
 
-// ─────────────────────────────────────────────
-// Cache the demo org ID to avoid a DB lookup on every request.
-// We only cache successful resolutions to avoid sticky null-state if
-// the org is created after server startup.
-// ─────────────────────────────────────────────
-const demoOrgIds = new Map<string, string>()
-const DEFAULT_PREVIEW_DEMO_ORG_SLUG = 'reqcore-demo'
-
 const PUBLIC_APPLY_PATH_REGEX = /^\/api\/public\/jobs\/([^/]+)\/apply\/?$/
 
 function throwDemoReadOnlyError(): never {
   throw createPreviewReadOnlyError()
-}
-
-interface DemoSlugsResult {
-  slugs: string[]
-  /** True only when DEMO_ORG_SLUG was explicitly set by the operator. */
-  isExplicitlyConfigured: boolean
-}
-
-function getConfiguredDemoSlugs(): DemoSlugsResult {
-  const slugs = new Set<string>()
-  let isExplicitlyConfigured = false
-
-  if (env.DEMO_ORG_SLUG) {
-    slugs.add(env.DEMO_ORG_SLUG)
-    isExplicitlyConfigured = true
-  }
-
-  if (isRailwayPreviewEnvironment(env.RAILWAY_ENVIRONMENT_NAME)) {
-    slugs.add(DEFAULT_PREVIEW_DEMO_ORG_SLUG)
-  }
-
-  return { slugs: [...slugs], isExplicitlyConfigured }
-}
-
-async function getDemoOrgIds(slugs: string[]): Promise<Set<string>> {
-  const ids = new Set<string>()
-
-  for (const slug of slugs) {
-    const cached = demoOrgIds.get(slug)
-    if (cached) {
-      ids.add(cached)
-      continue
-    }
-
-    const [org] = await db
-      .select({ id: schema.organization.id })
-      .from(schema.organization)
-      .where(eq(schema.organization.slug, slug))
-      .limit(1)
-
-    if (!org?.id) {
-      continue
-    }
-
-    demoOrgIds.set(slug, org.id)
-    ids.add(org.id)
-  }
-
-  return ids
 }
 
 const WRITE_METHODS = new Set(['POST', 'PATCH', 'PUT', 'DELETE'])

--- a/server/utils/demoOrg.ts
+++ b/server/utils/demoOrg.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared helpers for detecting the demo organization across the server.
+ *
+ * Used by:
+ * - `server/middleware/demo-guard.ts` to block writes on the demo org
+ * - `server/utils/trackEvent.ts` to tag PostHog events with `is_demo: true`
+ *   so the demo session can be filtered out of funnels and dashboards.
+ *
+ * Demo-org IDs are cached after the first DB lookup. We never cache a
+ * negative result so that orgs created after server boot are picked up
+ * on the next request.
+ */
+import { eq } from 'drizzle-orm'
+import * as schema from '../database/schema'
+import { isRailwayPreviewEnvironment } from './env'
+
+const demoOrgIdBySlug = new Map<string, string>()
+const demoOrgIdSet = new Set<string>()
+const DEFAULT_PREVIEW_DEMO_ORG_SLUG = 'reqcore-demo'
+
+export interface DemoSlugsResult {
+  slugs: string[]
+  /** True only when DEMO_ORG_SLUG was explicitly set by the operator. */
+  isExplicitlyConfigured: boolean
+}
+
+export function getConfiguredDemoSlugs(): DemoSlugsResult {
+  const slugs = new Set<string>()
+  let isExplicitlyConfigured = false
+
+  if (env.DEMO_ORG_SLUG) {
+    slugs.add(env.DEMO_ORG_SLUG)
+    isExplicitlyConfigured = true
+  }
+
+  if (isRailwayPreviewEnvironment(env.RAILWAY_ENVIRONMENT_NAME)) {
+    slugs.add(DEFAULT_PREVIEW_DEMO_ORG_SLUG)
+  }
+
+  return { slugs: [...slugs], isExplicitlyConfigured }
+}
+
+/**
+ * Resolve the configured demo slugs to organisation IDs.
+ *
+ * Falls back to a synchronous cache lookup when possible to avoid an
+ * extra DB hit on every authenticated request. The first request after
+ * boot still pays the lookup cost.
+ */
+export async function getDemoOrgIds(slugs?: string[]): Promise<Set<string>> {
+  const slugList = slugs ?? getConfiguredDemoSlugs().slugs
+  const ids = new Set<string>()
+
+  for (const slug of slugList) {
+    const cached = demoOrgIdBySlug.get(slug)
+    if (cached) {
+      ids.add(cached)
+      continue
+    }
+
+    const [org] = await db
+      .select({ id: schema.organization.id })
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, slug))
+      .limit(1)
+
+    if (!org?.id) continue
+
+    demoOrgIdBySlug.set(slug, org.id)
+    demoOrgIdSet.add(org.id)
+    ids.add(org.id)
+  }
+
+  return ids
+}
+
+/**
+ * True when the given organisation id matches a configured demo org.
+ *
+ * Returns false (not null) when no demo org is configured or the org
+ * cannot be resolved — callers can safely treat the result as a boolean
+ * funnel filter.
+ */
+export async function isDemoOrgId(orgId: string | null | undefined): Promise<boolean> {
+  if (!orgId) return false
+  const ids = await getDemoOrgIds()
+  return ids.has(orgId)
+}

--- a/server/utils/trackEvent.ts
+++ b/server/utils/trackEvent.ts
@@ -1,4 +1,5 @@
 import type { H3Event } from 'h3'
+import { isDemoOrgId } from './demoOrg'
 
 interface TrackSession {
   user: { id: string }
@@ -12,6 +13,9 @@ interface TrackSession {
  * - `distinctId` from the authenticated session
  * - `organization` group for org-scoped analytics
  * - Request context: HTTP method, path, user agent
+ * - `is_demo: true` when the active organisation matches the configured
+ *   demo org — lets PostHog funnels filter the demo session out so it
+ *   does not skew metrics.
  *
  * Usage in API handlers:
  *   const session = await requirePermission(event, { application: ['update'] })
@@ -23,33 +27,42 @@ export function trackEvent(
   eventName: string,
   properties?: Record<string, unknown>,
 ): void {
-  try {
-    const ph = useServerPostHog()
-    if (!ph) return
+  // Resolve the demo flag asynchronously, then capture. We swallow any
+  // tracking errors so they never break the primary operation.
+  const orgId = session?.session?.activeOrganizationId
+  void isDemoOrgId(orgId)
+    .catch(() => false)
+    .then((isDemo) => {
+      try {
+        const ph = useServerPostHog()
+        if (!ph) return
 
-    const userId = session?.user?.id || 'anonymous'
-    const orgId = session?.session?.activeOrganizationId
+        const userId = session?.user?.id || 'anonymous'
 
-    const headers = getHeaders(event)
-    const method = getMethod(event)
-    const path = getRequestURL(event).pathname
+        const headers = getHeaders(event)
+        const method = getMethod(event)
+        const path = getRequestURL(event).pathname
 
-    ph.capture({
-      distinctId: userId,
-      event: eventName,
-      groups: orgId ? { organization: orgId } : undefined,
-      properties: {
-        // Request context — invaluable for debugging per-user issues
-        $request_method: method,
-        $request_path: path,
-        $user_agent: headers['user-agent'],
-        ...properties,
-      },
+        ph.capture({
+          distinctId: userId,
+          event: eventName,
+          groups: orgId ? { organization: orgId } : undefined,
+          properties: {
+            // Request context — invaluable for debugging per-user issues
+            $request_method: method,
+            $request_path: path,
+            $user_agent: headers['user-agent'],
+            // Demo tag — funnels & dashboards filter `is_demo != true`
+            // to exclude the public demo session from real-user metrics.
+            is_demo: isDemo,
+            ...properties,
+          },
+        })
+      }
+      catch {
+        // Tracking must never break the primary operation
+      }
     })
-  }
-  catch {
-    // Tracking must never break the primary operation
-  }
 }
 
 /**

--- a/tests/unit/posthog-cookieless.test.ts
+++ b/tests/unit/posthog-cookieless.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Verifies the two-tier PostHog consent + identity model.
+ *
+ * Default state (no consent / declined):
+ *   - persistence: 'memory' (no cookies, no localStorage)
+ *   - person_profiles: 'identified_only'
+ *   - logged-in users identified by opaque user.id ONLY (no PII)
+ *   - org group set with id ONLY
+ *   - $ip / $initial_ip denylisted
+ *
+ * Accepted state:
+ *   - persistence upgraded to 'localStorage+cookie'
+ *   - identify() re-fired with email + name → aliases anon distinct id
+ *   - org group enriched with org name
+ *   - UTM + first-touch attribution captured
+ */
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const ROOT = resolve(__dirname, '../..')
+const read = (rel: string) => readFileSync(resolve(ROOT, rel), 'utf8')
+
+describe('PostHog default cookieless config', () => {
+  const nuxtConfig = read('nuxt.config.ts')
+
+  it('uses memory-only persistence by default (no storage without consent)', () => {
+    expect(nuxtConfig).toMatch(/persistence:\s*["']memory["']/)
+  })
+
+  it('creates person profiles only for identified users', () => {
+    expect(nuxtConfig).toMatch(/person_profiles:\s*["']identified_only["']/)
+  })
+
+  it('denylists IP address properties for GDPR data minimisation', () => {
+    expect(nuxtConfig).toMatch(/property_denylist:\s*\[\s*["']\$ip["']\s*,\s*["']\$initial_ip["']\s*\]/)
+  })
+
+  it('keeps invasive features disabled', () => {
+    expect(nuxtConfig).toMatch(/autocapture:\s*false/)
+    expect(nuxtConfig).toMatch(/disable_session_recording:\s*true/)
+    expect(nuxtConfig).toMatch(/disable_surveys:\s*true/)
+  })
+})
+
+describe('Consent surface (banner + composable)', () => {
+  it('exposes the consent cookie name shared across subdomains', () => {
+    const consent = read('app/composables/useAnalyticsConsent.ts')
+    expect(consent).toMatch(/CONSENT_COOKIE_NAME = ['"]reqcore-consent['"]/)
+  })
+
+  it('writes the consent cookie with a cross-subdomain domain option', () => {
+    const consent = read('app/composables/useAnalyticsConsent.ts')
+    expect(consent).toMatch(/domain:\s*cookieDomain/)
+    expect(consent).toMatch(/sameSite:\s*['"]lax['"]/)
+  })
+
+  it('upgrades persistence to localStorage+cookie on accept', () => {
+    const consent = read('app/composables/useAnalyticsConsent.ts')
+    expect(consent).toMatch(/set_config\(\s*\{[^}]*persistence:\s*['"]localStorage\+cookie['"]/s)
+    expect(consent).toMatch(/cross_subdomain_cookie:\s*true/)
+  })
+
+  it('does NOT touch PostHog config on decline (cookieless mode continues)', () => {
+    const consent = read('app/composables/useAnalyticsConsent.ts')
+    // Isolate the decline function body and assert no upgrade calls inside.
+    const match = consent.match(/function declineAnalytics\(\)\s*\{([\s\S]*?)\n\s*\}/)
+    expect(match, 'declineAnalytics body found').toBeTruthy()
+    const body = match![1]!
+    expect(body).not.toMatch(/set_config/)
+    expect(body).not.toMatch(/opt_out/)
+    expect(body).not.toMatch(/identify/)
+  })
+
+  it('captures UTM + first-touch attribution after consent', () => {
+    const consent = read('app/composables/useAnalyticsConsent.ts')
+    expect(consent).toMatch(/utm_source/)
+    expect(consent).toMatch(/initial_referrer/)
+    expect(consent).toMatch(/consent_granted/)
+  })
+
+  it('renders ConsentBanner only while consent is undecided', () => {
+    expect(existsSync(resolve(ROOT, 'app/components/ConsentBanner.vue'))).toBe(true)
+    const banner = read('app/components/ConsentBanner.vue')
+    expect(banner).toMatch(/v-if="needsConsent"/)
+    expect(banner).toMatch(/acceptAnalytics/)
+    expect(banner).toMatch(/declineAnalytics/)
+
+    const appVue = read('app/app.vue')
+    expect(appVue).toMatch(/<ConsentBanner\s*\/>/)
+  })
+})
+
+describe('PostHog identity (PII gated on consent)', () => {
+  const identityComposable = read('app/composables/usePostHogIdentity.ts')
+  const identityPlugin = read('app/plugins/posthog-identity.client.ts')
+
+  it('always identifies logged-in users by opaque user.id (returning-user tracking)', () => {
+    expect(identityComposable).toMatch(/identify\(user\.id\)/)
+  })
+
+  it('forwards email + name ONLY when consent has been granted', () => {
+    expect(identityComposable).toMatch(/if\s*\(\s*consented\s*\)/)
+    expect(identityComposable).toMatch(/email:\s*user\.email/)
+    expect(identityComposable).toMatch(/name:\s*user\.name/)
+  })
+
+  it('plugin identify helper accepts an optional properties bag', () => {
+    expect(identityPlugin).toMatch(/posthogIdentifyUser:\s*\(\s*userId:\s*string\s*,\s*properties\?:/)
+    // When properties are absent, identify is called with id only (no PII).
+    expect(identityPlugin).toMatch(/posthog\.identify\(userId\)/)
+    // When properties are present, identify forwards them — this is the call
+    // that aliases the anon distinct id to the user id with PII attached.
+    expect(identityPlugin).toMatch(/posthog\.identify\(userId,\s*properties\)/)
+  })
+
+  it('groups by org id always; org name only when consented', () => {
+    expect(identityPlugin).toMatch(/posthog\.group\(\s*['"]organization['"]\s*,\s*org\.id\s*\)/)
+    expect(identityPlugin).toMatch(/posthog\.group\(\s*['"]organization['"]\s*,\s*org\.id\s*,\s*\{\s*name:\s*org\.name\s*\}/)
+  })
+
+  it('resets PostHog on log-out regardless of consent', () => {
+    expect(identityComposable).toMatch(/posthogReset/)
+  })
+
+  it('upgrades persistence on boot for already-consented returning visitors', () => {
+    expect(identityPlugin).toMatch(/consentCookie\.value === ['"]granted['"]/)
+    expect(identityPlugin).toMatch(/persistence:\s*['"]localStorage\+cookie['"]/)
+  })
+})
+
+describe('PostHog URL-property sanitisation', () => {
+  const identityPlugin = read('app/plugins/posthog-identity.client.ts')
+
+  it('strips query strings and hashes from referrer/current_url props', () => {
+    expect(identityPlugin).toMatch(/\$current_url/)
+    expect(identityPlugin).toMatch(/\$referrer/)
+    expect(identityPlugin).toMatch(/u\.search = ''/)
+    expect(identityPlugin).toMatch(/u\.hash = ''/)
+  })
+})
+
+describe('useTrack composable', () => {
+  const useTrack = read('app/composables/useTrack.ts')
+
+  it('captures events directly (no consent gating, no opt-in check)', () => {
+    expect(useTrack).not.toMatch(/has_opted_in_capturing/)
+    expect(useTrack).not.toMatch(/useAnalyticsConsent/)
+    expect(useTrack).toMatch(/ph\.capture\(\s*eventName/)
+  })
+})
+
+describe('Server-side trackEvent (stable distinct id)', () => {
+  const trackEvent = read('server/utils/trackEvent.ts')
+
+  it('uses the auth user id as the PostHog distinct id (stable across sessions)', () => {
+    expect(trackEvent).toMatch(/distinctId:\s*userId/)
+    expect(trackEvent).toMatch(/session\?\.user\?\.id/)
+  })
+
+  it('groups events by organization id for per-org analytics', () => {
+    expect(trackEvent).toMatch(/groups:\s*orgId\s*\?\s*\{\s*organization:\s*orgId\s*\}/)
+  })
+})
+
+describe('Cross-domain consent forwarding (marketing → app)', () => {
+  const identityPlugin = read('app/plugins/posthog-identity.client.ts')
+
+  it('only honours ?ph_consent=granted from a trusted reqcore.com referrer', () => {
+    expect(identityPlugin).toMatch(/ref\.hostname === ['"]reqcore\.com['"]/)
+    expect(identityPlugin).toMatch(/ref\.hostname\.endsWith\(['"]\.reqcore\.com['"]/)
+  })
+
+  it('only aliases the marketing distinct id when consent is already granted', () => {
+    expect(identityPlugin).toMatch(/isValidDistinctId && consentCookie\.value === ['"]granted['"]/)
+  })
+
+  it('validates the marketing distinct id format before passing to alias()', () => {
+    expect(identityPlugin).toMatch(/\/\^\[\\w-\]\{10,100\}\$\//)
+  })
+})
+
+describe('Demo account isolation (is_demo super property)', () => {
+  // Marketing & internal demo behaviour must never skew real-user funnels.
+  // We tag the demo session with `is_demo: true` so dashboards can filter
+  // it out — server-side via event property, client-side via super property
+  // + person property.
+
+  it('client identity composable references both demo signals (email + slug)', () => {
+    const identity = read('app/composables/usePostHogIdentity.ts')
+    expect(identity).toMatch(/liveDemoEmail/)
+    expect(identity).toMatch(/demoOrgSlug/)
+  })
+
+  it('client identity calls the demo flag setter from both watchers', () => {
+    const identity = read('app/composables/usePostHogIdentity.ts')
+    // user-watcher: tag based on email
+    expect(identity).toMatch(/setDemoFlag\(user\.email === liveDemoEmail\)/)
+    // org-watcher: tag based on slug
+    expect(identity).toMatch(/org\.slug === demoOrgSlug/)
+  })
+
+  it('plugin exposes posthogSetDemoFlag as a super-property toggle', () => {
+    const plugin = read('app/plugins/posthog-identity.client.ts')
+    expect(plugin).toMatch(/posthogSetDemoFlag:/)
+    // Super property → automatically attached to every event.
+    expect(plugin).toMatch(/posthog\.register\(\s*\{\s*is_demo:\s*true\s*\}/)
+    // Cleared on demand so a real user signing in after demo isn't tagged.
+    expect(plugin).toMatch(/posthog\.unregister\(['"]is_demo['"]\)/)
+    // Person-level tag survives across sessions for the demo profile.
+    expect(plugin).toMatch(/setPersonProperties\(\s*\{\s*is_demo:\s*true\s*\}/)
+  })
+
+  it('server trackEvent looks up the demo org id and tags every event', () => {
+    const trackEvent = read('server/utils/trackEvent.ts')
+    expect(trackEvent).toMatch(/from ['"]\.\/demoOrg['"]/)
+    expect(trackEvent).toMatch(/isDemoOrgId\(orgId\)/)
+    expect(trackEvent).toMatch(/is_demo:\s*isDemo/)
+  })
+
+  it('shared demoOrg helper exports the cached demo-org lookup', () => {
+    const demoOrg = read('server/utils/demoOrg.ts')
+    expect(demoOrg).toMatch(/export async function isDemoOrgId/)
+    expect(demoOrg).toMatch(/export async function getDemoOrgIds/)
+    expect(demoOrg).toMatch(/export function getConfiguredDemoSlugs/)
+  })
+})


### PR DESCRIPTION
- Introduced a two-tier consent model in useAnalyticsConsent composable.
- Updated usePostHogIdentity to handle PII based on consent.
- Enhanced useTrack to capture events without consent gating.
- Added demo account isolation with is_demo super property for analytics.
- Implemented URL property sanitization in posthog-identity plugin.
- Updated nuxt.config for cookieless tracking and GDPR compliance.
- Created unit tests to verify consent model and identity handling.

## Summary

- What does this PR change?
- Why is this needed?

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Validation

- [ ] I tested locally
- [ ] I added/updated relevant documentation
- [ ] I verified multi-tenant scoping and auth behavior for affected API paths

## DCO

- [ ] All commits in this PR are signed off (`Signed-off-by`) via `git commit -s`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added demo account detection and isolation for analytics tracking.

* **Privacy & Security**
  * Enhanced privacy by removing IP data from analytics events.
  * Refined analytics persistence modes based on user consent preferences.
  * Improved identity tracking with consent-aware personal data handling.

* **Bug Fixes**
  * Corrected analytics event capture and consent decision logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->